### PR TITLE
fix #88 add commit message standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   },
   "scripts": {
     "test": "grunt codecheck --verbose"
+  },
+  "dependencies": {
+    "grunt-commit-message-verify": "^0.1.0"
   }
 }


### PR DESCRIPTION
Added https://github.com/jakub-g/grunt-commit-message-verify to test task

fixes #88 
