### PR TITLE
fix(logical operators): replace and/or with &&/|| because of higher precedence

### DIFF
--- a/_functions.php
+++ b/_functions.php
@@ -375,7 +375,7 @@ function getforminput($text)
 // -- LOGIN -- //
 
 $login_per_cookie = false;
-if (isset($_COOKIE[ 'ws_auth' ]) and !isset($_SESSION[ 'ws_auth' ])) {
+if (isset($_COOKIE[ 'ws_auth' ]) && !isset($_SESSION[ 'ws_auth' ])) {
     $login_per_cookie = true;
     $_SESSION[ 'ws_auth' ] = $_COOKIE[ 'ws_auth' ];
 }
@@ -408,7 +408,7 @@ if (isset($_GET[ 'site' ])) {
 } else {
     $site = '';
 }
-if ($closed and !isanyadmin($userID)) {
+if ($closed && !isanyadmin($userID)) {
     $dl = mysqli_fetch_array(safe_query("SELECT * FROM `" . PREFIX . "lock` LIMIT 0,1"));
     $reason = $dl[ 'reason' ];
     $time = $dl[ 'time' ];

--- a/admin/countries.php
+++ b/admin/countries.php
@@ -142,7 +142,7 @@ if ($action == "add") {
     }
     $CAPCLASS = new \webspell\Captcha;
     if ($CAPCLASS->checkCaptcha(0, $_POST[ 'captcha_hash' ])) {
-        if ($country and $short) {
+        if ($country && $short) {
             $file_ext = strtolower(mb_substr($icon[ 'name' ], strrpos($icon[ 'name' ], ".")));
             if ($file_ext == ".gif") {
                 safe_query(
@@ -188,7 +188,7 @@ if ($action == "add") {
     }
     $CAPCLASS = new \webspell\Captcha;
     if ($CAPCLASS->checkCaptcha(0, $_POST[ 'captcha_hash' ])) {
-        if ($country and $short) {
+        if ($country && $short) {
             if ($icon[ 'name' ] == "") {
                 if (
                     safe_query(

--- a/admin/database.php
+++ b/admin/database.php
@@ -185,7 +185,7 @@ if ($action == "optimize") {
             header("Cache-Control: must-revalidate, post-check=0, pre-check=0");
             header("Content-Type: application/force-download");
             header("Content-Description: File Transfer");
-            if (is_integer(mb_strpos(strtolower($_SERVER[ "HTTP_USER_AGENT" ]), "msie")) and
+            if (is_integer(mb_strpos(strtolower($_SERVER[ "HTTP_USER_AGENT" ]), "msie")) &&
                 is_integer(mb_strpos(strtolower($_SERVER[ "HTTP_USER_AGENT" ]), "win"))
             ) {
                 header("Content-Disposition: filename=backup-" . strtolower(date("D-d-M-Y")) . ".sql;");

--- a/admin/filecategories.php
+++ b/admin/filecategories.php
@@ -27,7 +27,7 @@
 
 $_language->readModule('filecategorys');
 
-if (!isfileadmin($userID) or mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 15) != "admincenter.php") {
+if (!isfileadmin($userID) || mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 15) != "admincenter.php") {
     die($_language->module[ 'access_denied' ]);
 }
 
@@ -87,7 +87,7 @@ function delete_category($filecat)
     safe_query("DELETE FROM " . PREFIX . "files_categorys WHERE filecatID='" . $filecat . "'");
     $files = safe_query("SELECT * FROM " . PREFIX . "files WHERE filecatID='" . $filecat . "'");
     while ($ds = mysqli_fetch_array($files)) {
-        if (stristr($ds[ 'file' ], "http://") or stristr($ds[ 'file' ], "ftp://")) {
+        if (stristr($ds[ 'file' ], "http://") || stristr($ds[ 'file' ], "ftp://")) {
             @unlink('../downloads/' . $ds[ 'file' ]);
         }
     }

--- a/admin/gallery.php
+++ b/admin/gallery.php
@@ -471,7 +471,7 @@ if ($part == "groups") {
                 if ($file != "." && $file != "..") {
                     if (is_file($dir . $file)) {
                         if ($info = getimagesize($dir . $file)) {
-                            if ($info[ 2 ] == 1 or $info[ 2 ] == 2 || $info[ 2 ] == 3) {
+                            if ($info[ 2 ] == 1 || $info[ 2 ] == 2 || $info[ 2 ] == 3) {
                                 $pics[ ] = $file;
                             }
                         }

--- a/admin/games.php
+++ b/admin/games.php
@@ -111,7 +111,7 @@ if ($action == "add") {
     $tag = $_POST[ "tag" ];
     $CAPCLASS = new \webspell\Captcha;
     if ($CAPCLASS->checkCaptcha(0, $_POST[ 'captcha_hash' ])) {
-        if ($name and $tag) {
+        if ($name && $tag) {
             $file_ext = strtolower(mb_substr($icon[ 'name' ], strrpos($icon[ 'name' ], ".")));
             if ($file_ext == ".gif") {
                 safe_query(
@@ -142,7 +142,7 @@ if ($action == "add") {
     $tag = $_POST[ "tag" ];
     $CAPCLASS = new \webspell\Captcha;
     if ($CAPCLASS->checkCaptcha(0, $_POST[ 'captcha_hash' ])) {
-        if ($name and $tag) {
+        if ($name && $tag) {
             if ($icon[ 'name' ] == "") {
                 if (safe_query(
                     "UPDATE " . PREFIX . "games SET name='" . $name . "', tag='" . $tag .

--- a/admin/group-users.php
+++ b/admin/group-users.php
@@ -70,7 +70,7 @@ if (isset($_GET[ 'ajax' ])) {
 }
 $_language->readModule('group-users');
 
-if (!isforumadmin($userID) or mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 15) != "admincenter.php") {
+if (!isforumadmin($userID) || mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 15) != "admincenter.php") {
     die($_language->module[ 'access_denied' ]);
 }
 
@@ -157,7 +157,7 @@ if (isset($_GET[ 'action' ])) {
             }
         }
     }
-    if (in_array(4, $_POST[ 'users' ]) or !count($_POST[ 'users' ]) or empty($_GET[ 'users' ])) {
+    if (in_array(4, $_POST[ 'users' ]) || !count($_POST[ 'users' ]) || empty($_GET[ 'users' ])) {
         $query = safe_query("SELECT userID FROM `" . PREFIX . "user`");
         while ($ds = mysqli_fetch_array($query)) {
             if (!in_array($ds[ 'userID' ], $users)) {
@@ -225,11 +225,11 @@ if (isset($_GET[ 'action' ])) {
         echo '</tr>';
         $n = 1;
         $skip = $anz_users_page * ($page - 1);
-    for ($z = $skip; $z < ($skip + $anz_users_page) and $z < $anz_users; $z++) {
-        if ($n % 2) {
-            $td = 'td1';
-        } else {
-            $td = 'td2';
+        for ($z = $skip; $z < ($skip + $anz_users_page) && $z < $anz_users; $z++) {
+            if ($n % 2) {
+                $td = 'td1';
+            } else {
+                $td = 'td2';
         }
         echo '<tr><td class="' . $td . '">' . strip_tags(stripslashes(getnickname($users[ $z ]))) . '</td>';
         for ($i = 0; $i < $groups_anz; $i++) {

--- a/admin/group-users.php
+++ b/admin/group-users.php
@@ -98,7 +98,7 @@ if (isset($_GET[ 'action' ])) {
     if (isset($_GET[ 'addfield' ])) {
         $_POST[ 'addfield' ] = $_GET[ 'addfield' ];
     }
-        $users = [];
+    $users = [];
     if (in_array(0, $_POST[ 'users' ])) {
         $query = safe_query("SELECT userID FROM `" . PREFIX . "squads_members`");
         while ($ds = mysqli_fetch_array($query)) {
@@ -165,21 +165,23 @@ if (isset($_GET[ 'action' ])) {
             }
         }
     }
-        $groups = [];
+    $groups = [];
     if (isset($_POST[ 'groups' ])) {
         $grps = $_POST[ 'groups' ];
     } else {
         $grps = [1];
     }
-        $sql = safe_query("SELECT * FROM " . PREFIX . "forum_groups");
+
+    $sql = safe_query("SELECT * FROM " . PREFIX . "forum_groups");
     while ($ds = mysqli_fetch_array($sql)) {
         if (in_array($ds[ 'fgrID' ], $grps)) {
             $groups[ ] = ['fgrID' => $ds[ 'fgrID' ], 'name' => getinput($ds[ 'name' ])];
         }
     }
-        $groups_anz = count($groups);
-        $anz_users = count($users);
-        $pages = ceil($anz_users / $anz_users_page);
+
+    $groups_anz = count($groups);
+    $anz_users = count($users);
+    $pages = ceil($anz_users / $anz_users_page);
     if ($pages > 1) {
         echo makepagelink(
             "admincenter.php?site=group-users&amp;action=show&amp;users=" .
@@ -189,10 +191,10 @@ if (isset($_GET[ 'action' ])) {
             $pages
         );
     }
-        echo '<h1>&curren; <a href="admincenter.php?site=group-users" class="white">' .
-            $_language->module[ 'group_users' ] . '</a> &raquo; ' . $_language->module[ 'edit_group_users' ] .
-            '</h1>';
-        echo '<script type="text/javascript">
+    echo '<h1>&curren; <a href="admincenter.php?site=group-users" class="white">' .
+        $_language->module[ 'group_users' ] . '</a> &raquo; ' . $_language->module[ 'edit_group_users' ] .
+        '</h1>';
+    echo '<script type="text/javascript">
     function setUser(userID,group,status){
         fetch(
             "group-users.php?ajax=true&action=usergroups&user="+userID+"&group="+group+"&state="+status,
@@ -222,14 +224,14 @@ if (isset($_GET[ 'action' ])) {
     for ($i = 0; $i < $groups_anz; $i++) {
         echo '<td class="title"><b>' . $groups[ $i ][ 'name' ] . '</b></td>';
     }
-        echo '</tr>';
-        $n = 1;
-        $skip = $anz_users_page * ($page - 1);
-        for ($z = $skip; $z < ($skip + $anz_users_page) && $z < $anz_users; $z++) {
-            if ($n % 2) {
-                $td = 'td1';
-            } else {
-                $td = 'td2';
+    echo '</tr>';
+    $n = 1;
+    $skip = $anz_users_page * ($page - 1);
+    for ($z = $skip; $z < ($skip + $anz_users_page) && $z < $anz_users; $z++) {
+        if ($n % 2) {
+            $td = 'td1';
+        } else {
+            $td = 'td2';
         }
         echo '<tr><td class="' . $td . '">' . strip_tags(stripslashes(getnickname($users[ $z ]))) . '</td>';
         for ($i = 0; $i < $groups_anz; $i++) {
@@ -245,7 +247,7 @@ if (isset($_GET[ 'action' ])) {
         echo '</tr>';
         $n++;
     }
-        echo '<tr><td class="td_head">
+    echo '<tr><td class="td_head">
             <input type="checkbox" name="ALL" value="ALL" onclick="SelectAllEval(this.form);" /> ' .
             $_language->module[ 'select_all' ] . '
         </td>

--- a/admin/groups.php
+++ b/admin/groups.php
@@ -27,7 +27,7 @@
 
 $_language->readModule('groups');
 
-if (!isforumadmin($userID) or mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 15) != "admincenter.php") {
+if (!isforumadmin($userID) || mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 15) != "admincenter.php") {
     die($_language->module[ 'access_denied' ]);
 }
 

--- a/admin/lock.php
+++ b/admin/lock.php
@@ -36,7 +36,7 @@ echo '<h1>&curren; <a href="admincenter.php?site=settings" class="white">' . $_l
 
 if (!$closed) {
 
-    if (isset($_POST[ 'submit' ]) != "" and ispageadmin($userID)) {
+    if (isset($_POST[ 'submit' ]) != "" && ispageadmin($userID)) {
         $CAPCLASS = new \webspell\Captcha;
         if ($CAPCLASS->checkCaptcha(0, $_POST[ 'captcha_hash' ])) {
             if (mysqli_num_rows(safe_query("SELECT * FROM `" . PREFIX . "lock`"))) {
@@ -71,7 +71,7 @@ if (!$closed) {
     }
 } else {
 
-    if (isset($_POST[ 'submit' ]) != "" and isset($_POST[ 'unlock' ]) and ispageadmin($userID)) {
+    if (isset($_POST[ 'submit' ]) != "" && isset($_POST[ 'unlock' ]) && ispageadmin($userID)) {
         $CAPCLASS = new \webspell\Captcha;
         if ($CAPCLASS->checkCaptcha(0, $_POST[ 'captcha_hash' ])) {
             safe_query("UPDATE `" . PREFIX . "settings` SET closed='0'");

--- a/admin/members.php
+++ b/admin/members.php
@@ -54,7 +54,7 @@ if (isset($_GET[ 'delete' ])) {
         $id = $_GET[ 'id' ];
         $squadID = $_GET[ 'squadID' ];
         $squads = mysqli_num_rows(safe_query("SELECT userID FROM " . PREFIX . "squads_members WHERE userID='$id'"));
-        if ($squads < 2 and !issuperadmin($id)) {
+        if ($squads < 2 && !issuperadmin($id)) {
             safe_query("DELETE FROM " . PREFIX . "user_groups WHERE userID='$id'");
         }
 
@@ -106,7 +106,7 @@ if (isset($_POST[ 'saveedit' ])) {
         }
         $gallery = isset($_POST[ 'galleryadmin' ]);
 
-        if ($userID != $id or issuperadmin($userID)) {
+        if ($userID != $id || issuperadmin($userID)) {
 
             $ergebnis = safe_query("SELECT * FROM " . PREFIX . "user_groups WHERE userID='" . $id . "'");
             if (!mysqli_num_rows($ergebnis)) {
@@ -194,7 +194,7 @@ if (isset($_POST[ 'saveedit' ])) {
     }
 }
 
-if (isset($_GET[ 'action' ]) and $_GET[ 'action' ] == "edit") {
+if (isset($_GET[ 'action' ]) && $_GET[ 'action' ] == "edit") {
 
     echo '<h1>&curren; <a href="admincenter.php?site=members" class="white">' . $_language->module[ 'members' ] .
         '</a> &raquo; ' . $_language->module[ 'edit_member' ] . '</h1>';

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -167,7 +167,7 @@ if (isset($_POST[ 'submit' ])) {
     $langs = [];
     if ($dh = opendir($filepath)) {
         while ($file = mb_substr(readdir($dh), 0, 2)) {
-            if ($file != "." and $file != ".." and is_dir($filepath . $file)) {
+            if ($file != "." && $file != ".." && is_dir($filepath . $file)) {
                 if (isset($mysql_langs[ $file ])) {
                     $name = $mysql_langs[ $file ];
                     $name = ucfirst($name);

--- a/admin/squads.php
+++ b/admin/squads.php
@@ -27,7 +27,7 @@
 
 $_language->readModule('squads');
 
-if (!isuseradmin($userID) or mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 15) != "admincenter.php") {
+if (!isuseradmin($userID) || mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 15) != "admincenter.php") {
     die($_language->module[ 'access_denied' ]);
 }
 
@@ -41,7 +41,7 @@ if (isset($_GET[ 'delete' ])) {
                 "SELECT userID FROM " . PREFIX .
                 "squads_members WHERE userID='$ds[userID]'"
             ));
-            if ($squads < 2 and !issuperadmin($ds[ 'userID' ])) {
+            if ($squads < 2 && !issuperadmin($ds[ 'userID' ])) {
                 safe_query("DELETE FROM " . PREFIX . "user_groups WHERE userID='$ds[userID]'");
             }
         }

--- a/admin/static.php
+++ b/admin/static.php
@@ -34,7 +34,7 @@ if (!ispageadmin($userID) || mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 1
 if (isset($_POST[ 'save' ])) {
     $CAPCLASS = new \webspell\Captcha;
     if ($CAPCLASS->checkCaptcha(0, $_POST[ 'captcha_hash' ])) {
-        if (isset($_POST[ 'staticID' ]) and $_POST[ 'staticID' ]) {
+        if (isset($_POST[ 'staticID' ]) && $_POST[ 'staticID' ]) {
             safe_query(
                 "UPDATE
                     `" . PREFIX . "static`
@@ -72,7 +72,7 @@ if (isset($_POST[ 'save' ])) {
     }
 }
 
-if (isset($_GET[ 'action' ]) and $_GET[ 'action' ] == "add") {
+if (isset($_GET[ 'action' ]) && $_GET[ 'action' ] == "add") {
     $CAPCLASS = new \webspell\Captcha;
     $CAPCLASS->createTransaction();
     $hash = $CAPCLASS->getHash();
@@ -127,7 +127,7 @@ onsubmit="return chkFormular();">
 <input type="hidden" name="captcha_hash" value="' . $hash . '" />
 <br /><br /><input type="submit" name="save" value="' . $_language->module[ 'add_static_page' ] . '" />
 </form>';
-} elseif (isset($_GET[ 'action' ]) and $_GET[ 'action' ] == "edit") {
+} elseif (isset($_GET[ 'action' ]) && $_GET[ 'action' ] == "edit") {
 
     $_language->readModule('bbcode', true);
 

--- a/admin/update.php
+++ b/admin/update.php
@@ -50,11 +50,11 @@ if (!isset($_GET[ 'action' ])) {
         if ($latest[ 0 ] > $ownversion[ 0 ]) {
             echo '<a href="admincenter.php?site=update&amp;action=update"><font color="red">' .
                 $_language->module[ 'new_version' ] . '!</font></a>';
-        } elseif ($latest[ 0 ] == $ownversion[ 0 ] and $latest[ 1 ] > $ownversion[ 1 ]) {
+        } elseif ($latest[ 0 ] == $ownversion[ 0 ] && $latest[ 1 ] > $ownversion[ 1 ]) {
             echo '<a href="admincenter.php?site=update&amp;action=update">' . $_language->module[ 'new_functions' ] .
                 '&nbsp;' . $version[ 0 ] . '!</a>';
-        } elseif ($latest[ 0 ] == $ownversion[ 0 ] and
-            $latest[ 1 ] == $ownversion[ 1 ] and $latest[ 2 ] > $ownversion[ 2 ]
+        } elseif ($latest[ 0 ] == $ownversion[ 0 ] &&
+            $latest[ 1 ] == $ownversion[ 1 ] && $latest[ 2 ] > $ownversion[ 2 ]
         ) {
             echo '<a href="admincenter.php?site=update&amp;action=update">' . $_language->module[ 'new_updates' ] .
                 '&nbsp;' . $version[ 0 ] . '!</a>';

--- a/admin/users.php
+++ b/admin/users.php
@@ -27,7 +27,7 @@
 
 $_language->readModule('users');
 
-if (!isuseradmin($userID) or mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 15) != "admincenter.php") {
+if (!isuseradmin($userID) || mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 15) != "admincenter.php") {
     die($_language->module[ 'access_denied' ]);
 }
 
@@ -65,7 +65,7 @@ if (isset($_POST[ 'add' ])) {
             $avatar_url = '';
         }
 
-        if ($avatar[ 'name' ] != "" or ($avatar_url != "" and $avatar_url != "http://")) {
+        if ($avatar[ 'name' ] != "" || ($avatar_url != "" && $avatar_url != "http://")) {
             if ($avatar[ 'name' ] != "") {
                 move_uploaded_file($avatar[ 'tmp_name' ], $filepath . $avatar[ 'name' ] . ".tmp");
             } else {
@@ -130,7 +130,7 @@ if (isset($_POST[ 'add' ])) {
             $userpic_url = '';
         }
 
-        if ($userpic[ 'name' ] != "" or ($userpic_url != "" and $userpic_url != "http://")) {
+        if ($userpic[ 'name' ] != "" || ($userpic_url != "" && $userpic_url != "http://")) {
             if ($userpic[ 'name' ] != "") {
                 move_uploaded_file($userpic[ 'tmp_name' ], $filepath . $userpic[ 'name' ] . ".tmp");
             } else {
@@ -256,7 +256,7 @@ if (isset($_POST[ 'add' ])) {
             "SELECT userID FROM " . PREFIX . "user WHERE (username='" . $newusername .
             "' OR nickname='" . $newnickname . "') "
         ));
-        if (!$anz and $newusername != "") {
+        if (!$anz && $newusername != "") {
             safe_query(
                 "INSERT INTO " . PREFIX .
                 "user ( username, nickname, password, registerdate, activated) VALUES( '" . $newusername . "', '" .
@@ -277,7 +277,7 @@ if (isset($_POST[ 'add' ])) {
     $CAPCLASS = new \webspell\Captcha;
     if ($CAPCLASS->checkCaptcha(0, $_GET[ 'captcha_hash' ])) {
         $id = $_GET[ 'id' ];
-        if (!issuperadmin($id) or (issuperadmin($id) and issuperadmin($userID))) {
+        if (!issuperadmin($id) || (issuperadmin($id) && issuperadmin($userID))) {
             safe_query("DELETE FROM " . PREFIX . "forum_moderators WHERE userID='$id'");
             safe_query("DELETE FROM " . PREFIX . "messenger WHERE touser='$id'");
             safe_query("DELETE FROM " . PREFIX . "squads_members WHERE userID='$id'");
@@ -372,7 +372,7 @@ if ($action == "activate") {
     $id = $_GET[ 'id' ];
 
     if ($userID != $id) {
-        if (!issuperadmin($id) or (issuperadmin($id) and issuperadmin($userID))) {
+        if (!issuperadmin($id) || (issuperadmin($id) && issuperadmin($userID))) {
             $CAPCLASS = new \webspell\Captcha;
             $CAPCLASS->createTransaction();
             $hash = $CAPCLASS->getHash();

--- a/admin/visitor_statistic.php
+++ b/admin/visitor_statistic.php
@@ -27,7 +27,7 @@
 
 $_language->readModule('visitor_statistic');
 
-if (!isanyadmin($userID) or mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 15) != "admincenter.php") {
+if (!isanyadmin($userID) || mb_substr(basename($_SERVER[ 'REQUEST_URI' ]), 0, 15) != "admincenter.php") {
     die($_language->module[ 'access_denied' ]);
 }
 

--- a/admin/visitor_statistic_image.php
+++ b/admin/visitor_statistic_image.php
@@ -244,7 +244,7 @@ foreach ($array as $i => $int) {
         imagefilledrectangle($im, $nr - 2, $offset_top + $y1 - 2, $nr + 2, $offset_top + $y1 + 2, $gelb);
     }
 
-    if (isset($_GET[ 'last' ]) and $_GET[ 'last' ] == "days") {
+    if (isset($_GET[ 'last' ]) && $_GET[ 'last' ] == "days") {
         imagestring(
             $im,
             2,
@@ -253,7 +253,7 @@ foreach ($array as $i => $int) {
             date("d", mktime(0, 0, 0, date("m"), date("d") - $count + $i, date("Y"))),
             $schwarz
         );
-    } elseif (isset($_GET[ 'last' ]) and $_GET[ 'last' ] == "months") {
+    } elseif (isset($_GET[ 'last' ]) && $_GET[ 'last' ] == "months") {
         imagestring(
             $im,
             2,

--- a/calendar.php
+++ b/calendar.php
@@ -289,7 +289,7 @@ function print_termine($tag, $month, $year)
                     $players = "";
                     $announce = "";
                     $adminaction = '';
-                    if (isclanmember($userID) or isanyadmin($userID)) {
+                    if (isclanmember($userID) || isanyadmin($userID)) {
                         $anmeldung =
                             safe_query(
                                 "SELECT * FROM " . PREFIX . "upcoming_announce WHERE upID='" . $ds['upID'] . "'"
@@ -518,7 +518,7 @@ if ($action === "savewar") {
             )"
     );
 
-    if (isset($chID) and $chID > 0) {
+    if (isset($chID) && $chID > 0) {
         safe_query("DELETE FROM " . PREFIX . "challenge WHERE chID='" . $chID . "'");
     }
 

--- a/cashbox.php
+++ b/cashbox.php
@@ -29,7 +29,7 @@ if (isset($site)) {
     $_language->readModule('cash_box');
 }
 
-if (isset($_POST[ 'save' ]) and $_POST[ 'save' ]) {
+if (isset($_POST[ 'save' ]) && $_POST[ 'save' ]) {
     include("_mysql.php");
     include("_settings.php");
     include("_functions.php");
@@ -67,7 +67,7 @@ if (isset($_POST[ 'save' ]) and $_POST[ 'save' ]) {
     $id = mysqli_insert_id($_database);
 
     header("Location: index.php?site=cashbox&id=$id");
-} elseif (isset($_POST[ 'saveedit' ]) and $_POST[ 'saveedit' ]) {
+} elseif (isset($_POST[ 'saveedit' ]) && $_POST[ 'saveedit' ]) {
     include("_mysql.php");
     include("_settings.php");
     include("_functions.php");
@@ -98,7 +98,7 @@ if (isset($_POST[ 'save' ]) and $_POST[ 'save' ]) {
     );
 
     header("Location: index.php?site=cashbox&id=$id");
-} elseif (isset($_GET[ 'delete' ]) and $_GET[ 'delete' ]) {
+} elseif (isset($_GET[ 'delete' ]) && $_GET[ 'delete' ]) {
     include("_mysql.php");
     include("_settings.php");
     include("_functions.php");
@@ -111,7 +111,7 @@ if (isset($_POST[ 'save' ]) and $_POST[ 'save' ]) {
     safe_query("DELETE FROM " . PREFIX . "cash_box_payed WHERE cashID='$id'");
 
     header("Location: index.php?site=cashbox");
-} elseif (isset($_POST[ 'pay' ]) and $_POST[ 'pay' ]) {
+} elseif (isset($_POST[ 'pay' ]) && $_POST[ 'pay' ]) {
     include("_mysql.php");
     include("_settings.php");
     include("_functions.php");
@@ -174,11 +174,11 @@ if (isset($_POST[ 'save' ]) and $_POST[ 'save' ]) {
     header("Location: index.php?site=cashbox&id=$id");
 }
 
-if (!isclanmember($userID) and !iscashadmin($userID)) {
+if (!isclanmember($userID) && !iscashadmin($userID)) {
     echo $_language->module[ 'clanmembers_only' ];
 } else {
 
-    if (isset($_GET[ 'action' ]) and $_GET[ 'action' ] == "new") {
+    if (isset($_GET[ 'action' ]) && $_GET[ 'action' ] == "new") {
 
         if (!iscashadmin($userID)) {
             die($_language->module[ 'no_access' ]);
@@ -203,7 +203,7 @@ if (!isclanmember($userID) and !iscashadmin($userID)) {
 
         eval ("\$cash_box_new = \"" . gettemplate("cash_box_new") . "\";");
         echo $cash_box_new;
-    } elseif (isset($_GET[ 'action' ]) and $_GET[ 'action' ] == "edit") {
+    } elseif (isset($_GET[ 'action' ]) && $_GET[ 'action' ] == "edit") {
 
         if (!iscashadmin($userID)) {
             die($_language->module[ 'no_access' ]);

--- a/challenge.php
+++ b/challenge.php
@@ -88,7 +88,7 @@ if ($action == "save" && isset($_POST['post'])) {
         }
     }
 
-    if (!count($error) and $run) {
+    if (!count($error) && $run) {
         $date = time();
         $touser = [];
         safe_query(

--- a/comments.php
+++ b/comments.php
@@ -228,7 +228,7 @@ if (isset($_POST[ 'savevisitorcomment' ])) {
     $referer = $_GET[ 'ref' ];
     $_language->readModule('comments');
     $_language->readModule('bbcode', true);
-    if (isfeedbackadmin($userID) or iscommentposter($userID, $id)) {
+    if (isfeedbackadmin($userID) || iscommentposter($userID, $id)) {
         if (!empty($id)) {
             $dt = safe_query("SELECT * FROM " . PREFIX . "comments WHERE commentID='" . (int)$id."'");
             if (mysqli_num_rows($dt)) {
@@ -257,7 +257,7 @@ if (isset($_POST[ 'savevisitorcomment' ])) {
     include("_settings.php");
     include("_functions.php");
 
-    if (!isfeedbackadmin($userID) and !iscommentposter($userID, $_POST[ 'commentID' ])) {
+    if (!isfeedbackadmin($userID) && !iscommentposter($userID, $_POST[ 'commentID' ])) {
         die('No access');
     }
 
@@ -503,7 +503,7 @@ if (isset($_POST[ 'savevisitorcomment' ])) {
             $content = cleartext($ds[ 'comment' ]);
             $content = toggle($content, $ds[ 'commentID' ]);
 
-            if (isfeedbackadmin($userID) or iscommentposter($userID, $ds[ 'commentID' ])) {
+            if (isfeedbackadmin($userID) || iscommentposter($userID, $ds[ 'commentID' ])) {
                 $edit =
                     '<a href="index.php?site=comments&amp;editcomment=true&amp;id=' . $ds[ 'commentID' ] . '&amp;ref=' .
                     urlencode($referer) . '" title="' . $_language->module[ 'edit_comment' ] .

--- a/contact.php
+++ b/contact.php
@@ -78,7 +78,7 @@ if ($action == "send") {
         }
     }
 
-    if (!count($fehler) and $run) {
+    if (!count($fehler) && $run) {
         $header = "From:$from\n";
         $header .= "Reply-To: $from\n";
         $header .= "Content-Type: text/html; charset=utf-8\n";

--- a/faq.php
+++ b/faq.php
@@ -36,7 +36,7 @@ if (isset($_GET[ 'action' ])) {
     $action = '';
 }
 
-if ($action == "faqcat" and is_numeric($_GET[ 'faqcatID' ])) {
+if ($action == "faqcat" && is_numeric($_GET[ 'faqcatID' ])) {
     if (ispageadmin($userID)) {
         echo '<input type="button" onclick="window.open(
             \'admin/admincenter.php?site=faq\',

--- a/forum.php
+++ b/forum.php
@@ -275,7 +275,7 @@ function boardmain()
             $ismod = ismoderator($userID, $db[ 'boardID' ]);
             $usergrp = 0;
             $writer = 'ro-';
-            if ($db[ 'writegrps' ] != "" and !$ismod) {
+            if ($db[ 'writegrps' ] != "" && !$ismod) {
                 $writegrps = explode(";", $db[ 'writegrps' ]);
                 foreach ($writegrps as $value) {
                     if (isinusergrp($value, $userID)) {
@@ -287,7 +287,7 @@ function boardmain()
             } else {
                 $writer = '';
             }
-            if ($db[ 'readgrps' ] != "" and !$usergrp and !$ismod) {
+            if ($db[ 'readgrps' ] != "" && !$usergrp && !$ismod) {
                 $readgrps = explode(";", $db[ 'readgrps' ]);
                 foreach ($readgrps as $value) {
                     if (isinusergrp($value, $userID)) {
@@ -377,7 +377,7 @@ function boardmain()
 
                 foreach ($array as $split) {
 
-                    if ($split != "" and in_array($split, $board_topics)) {
+                    if ($split != "" && in_array($split, $board_topics)) {
                         $found = true;
                         break;
                     }
@@ -415,7 +415,7 @@ function boardmain()
         $usergrp = 0;
         $writer = 'ro-';
         $ismod = ismoderator($userID, $db[ 'boardID' ]);
-        if ($db[ 'writegrps' ] != "" and !$ismod) {
+        if ($db[ 'writegrps' ] != "" && !$ismod) {
             $writegrps = explode(";", $db[ 'writegrps' ]);
             foreach ($writegrps as $value) {
                 if (isinusergrp($value, $userID)) {
@@ -427,7 +427,7 @@ function boardmain()
         } else {
             $writer = '';
         }
-        if ($db[ 'readgrps' ] != "" and !$usergrp and !$ismod) {
+        if ($db[ 'readgrps' ] != "" && !$usergrp && !$ismod) {
             $readgrps = explode(";", $db[ 'readgrps' ]);
             foreach ($readgrps as $value) {
                 if (isinusergrp($value, $userID)) {
@@ -510,7 +510,7 @@ function boardmain()
 
             foreach ($array as $split) {
 
-                if ($split != "" and in_array($split, $board_topics)) {
+                if ($split != "" && in_array($split, $board_topics)) {
                     $found = true;
                     break;
                 }
@@ -566,7 +566,7 @@ function showboard($board)
     $alle = safe_query("SELECT topicID FROM " . PREFIX . "forum_topics WHERE boardID='$board'");
     $gesamt = mysqli_num_rows($alle);
 
-    if ($action == "markall" and $userID) {
+    if ($action == "markall" && $userID) {
         $gv = mysqli_fetch_array(safe_query("SELECT topics FROM " . PREFIX . "user WHERE userID='$userID'"));
 
         $board_topics = [];
@@ -578,7 +578,7 @@ function showboard($board)
         $new = '|';
 
         foreach ($array as $split) {
-            if ($split != "" and !in_array($split, $board_topics)) {
+            if ($split != "" && !in_array($split, $board_topics)) {
                 $new .= $split . '|';
             }
         }
@@ -611,11 +611,11 @@ function showboard($board)
     $writer = 0;
 
     $ismod = false;
-    if (ismoderator($userID, $board) or isforumadmin($userID)) {
+    if (ismoderator($userID, $board) || isforumadmin($userID)) {
         $ismod = true;
     }
 
-    if ($db[ 'writegrps' ] != "" and !$ismod) {
+    if ($db[ 'writegrps' ] != "" && !$ismod) {
         $writegrps = explode(";", $db[ 'writegrps' ]);
         foreach ($writegrps as $value) {
             if (isinusergrp($value, $userID)) {
@@ -627,7 +627,7 @@ function showboard($board)
     } else {
         $writer = 1;
     }
-    if ($db[ 'readgrps' ] != "" and !$usergrp and !$ismod) {
+    if ($db[ 'readgrps' ] != "" && !$usergrp && !$ismod) {
         $readgrps = explode(";", $db[ 'readgrps' ]);
         foreach ($readgrps as $value) {
             if (isinusergrp($value, $userID)) {
@@ -774,7 +774,7 @@ function showboard($board)
             $poster =
                 '<a href="index.php?site=profile&amp;id=' . $dt[ 'userID' ] . '">' . getnickname($dt[ 'userID' ]) .
                 '</a>';
-            if (isset($posterID) and isclanmember($posterID)) {
+            if (isset($posterID) && isclanmember($posterID)) {
                 $member1 = ' <img src="images/icons/member.gif" alt="' . $_language->module[ 'clanmember' ] . '">';
             } else {
                 $member1 = '';
@@ -875,7 +875,7 @@ function showboard($board)
 }
 
 if (isset($_POST[ 'submit' ]) || isset($_POST[ 'movetopic' ]) || isset($_GET[ 'addtopic' ]) ||
-    isset($_POST[ 'addtopic' ]) || (isset($_GET[ 'action' ]) and $_GET[ 'action' ] == "admin-action") ||
+    isset($_POST[ 'addtopic' ]) || (isset($_GET[ 'action' ]) && $_GET[ 'action' ] == "admin-action") ||
     isset($_POST[ 'admaction' ])
 ) {
 
@@ -892,7 +892,7 @@ if (isset($_POST[ 'submit' ]) || isset($_POST[ 'movetopic' ]) || isset($_GET[ 'a
         $topicID = (int)$_POST[ 'topicID' ];
         $board = (int)$_POST[ 'board' ];
 
-        if (!isforumadmin($userID) and !ismoderator($userID, $board)) {
+        if (!isforumadmin($userID) && !ismoderator($userID, $board)) {
             die($_language->module[ 'no_access' ]);
         }
 
@@ -907,7 +907,7 @@ if (isset($_POST[ 'submit' ]) || isset($_POST[ 'movetopic' ]) || isset($_GET[ 'a
         $topicID = (int)$_POST[ 'topicID' ];
         $board = (int)$_POST[ 'board' ];
 
-        if (!isforumadmin($userID) and !ismoderator($userID, $board)) {
+        if (!isforumadmin($userID) && !ismoderator($userID, $board)) {
             die($_language->module[ 'no_access' ]);
         }
 
@@ -922,7 +922,7 @@ if (isset($_POST[ 'submit' ]) || isset($_POST[ 'movetopic' ]) || isset($_GET[ 'a
         $topicID = (int)$_POST[ 'topicID' ];
         $board = (int)$_POST[ 'board' ];
 
-        if (!isforumadmin($userID) and !ismoderator($userID, $board)) {
+        if (!isforumadmin($userID) && !ismoderator($userID, $board)) {
             die($_language->module[ 'no_access' ]);
         }
 
@@ -950,7 +950,7 @@ if (isset($_POST[ 'submit' ]) || isset($_POST[ 'movetopic' ]) || isset($_GET[ 'a
         $topicID = (int)$_POST[ 'topicID' ];
         $board = (int)$_POST[ 'board' ];
 
-        if (!isforumadmin($userID) and !ismoderator($userID, $board)) {
+        if (!isforumadmin($userID) && !ismoderator($userID, $board)) {
             die($_language->module[ 'no_access' ]);
         }
 
@@ -965,7 +965,7 @@ if (isset($_POST[ 'submit' ]) || isset($_POST[ 'movetopic' ]) || isset($_GET[ 'a
         $topicID = (int)$_POST[ 'topicID' ];
         $board = (int)$_POST[ 'board' ];
 
-        if (!isforumadmin($userID) and !ismoderator($userID, $board)) {
+        if (!isforumadmin($userID) && !ismoderator($userID, $board)) {
             die($_language->module[ 'no_access' ]);
         }
 
@@ -985,7 +985,7 @@ if (isset($_POST[ 'submit' ]) || isset($_POST[ 'movetopic' ]) || isset($_GET[ 'a
         }
         $board = (int)$_POST[ 'board' ];
 
-        if (!isforumadmin($userID) and !ismoderator($userID, $board)) {
+        if (!isforumadmin($userID) && !ismoderator($userID, $board)) {
             die($_language->module[ 'no_access' ]);
         }
         $last = safe_query("SELECT * FROM " . PREFIX . "forum_posts WHERE topicID = '$topicID' ");
@@ -1027,7 +1027,7 @@ if (isset($_POST[ 'submit' ]) || isset($_POST[ 'movetopic' ]) || isset($_GET[ 'a
         $toboard = (int)$_POST[ 'toboard' ];
         $topicID = (int)$_POST[ 'topicID' ];
 
-        if (!isanyadmin($userID) and !ismoderator($userID, getboardid($topicID))) {
+        if (!isanyadmin($userID) && !ismoderator($userID, getboardid($topicID))) {
             die($_language->module[ 'no_access' ]);
         }
 
@@ -1039,7 +1039,7 @@ if (isset($_POST[ 'submit' ]) || isset($_POST[ 'movetopic' ]) || isset($_GET[ 'a
         $ergebnis = safe_query("SELECT * FROM " . PREFIX . "forum_topics WHERE topicID='$topicID'");
         $ds = mysqli_fetch_array($ergebnis);
 
-        if (isset($_POST[ 'movelink' ]) and $ds[ 'boardID' ] != $toboard) {
+        if (isset($_POST[ 'movelink' ]) && $ds[ 'boardID' ] != $toboard) {
             safe_query(
                 "INSERT INTO " . PREFIX .
                 "forum_topics (boardID, icon, userID, date, topic, lastdate, lastposter, replys, views, closed, moveID)
@@ -1079,7 +1079,7 @@ if (isset($_POST[ 'submit' ]) || isset($_POST[ 'movetopic' ]) || isset($_GET[ 'a
         include("_settings.php");
         include('_functions.php');
         $_language->readModule('forum');
-        if (!isanyadmin($userID) and !ismoderator($userID, getboardid($_POST[ 'topicID' ]))) {
+        if (!isanyadmin($userID) && !ismoderator($userID, getboardid($_POST[ 'topicID' ]))) {
             die($_language->module[ 'no_access' ]);
         }
 
@@ -1324,7 +1324,7 @@ if (isset($_POST[ 'submit' ]) || isset($_POST[ 'movetopic' ]) || isset($_GET[ 'a
                 } else {
                     $signatur = '';
                 }
-                if (getemail($userID) and !getemailhide($userID)) {
+                if (getemail($userID) && !getemailhide($userID)) {
                     $email = '<a href="mailto:' . mail_protect(getemail($userID)) .
                         '"><img src="images/icons/email.gif" alt="email"></a>';
                 } else {

--- a/forum_topic.php
+++ b/forum_topic.php
@@ -104,7 +104,7 @@ if (isset($_POST['newreply']) && !isset($_POST['preview'])) {
         die($_language->module['no_access_write']);
     }
     $do_sticky = '';
-    if (isforumadmin($userID) or isanymoderator($userID, $ds['boardID'])) {
+    if (isforumadmin($userID) || isanymoderator($userID, $ds['boardID'])) {
         $do_sticky = (isset($_POST['sticky'])) ? ', sticky=1' : ', sticky=0';
     }
 
@@ -180,7 +180,7 @@ if (isset($_POST['newreply']) && !isset($_POST['preview'])) {
             }
         }
 
-        if (isset($_POST['notify']) and (bool)$_POST['notify']) {
+        if (isset($_POST['notify']) && (bool)$_POST['notify']) {
             safe_query(
                 "INSERT INTO " . PREFIX . "forum_notify (topicID, userID) VALUES('" . $topic . "', '" . $userID .
                 "') "
@@ -195,13 +195,13 @@ if (isset($_POST['newreply']) && !isset($_POST['preview'])) {
     }
     header("Location: index.php?site=forum_topic&topic=" . $topic . "&page=" . $page);
     exit();
-} elseif (isset($_POST['editreply']) and (bool)$_POST['editreply']) {
+} elseif (isset($_POST['editreply']) && (bool)$_POST['editreply']) {
     include("_mysql.php");
     include("_settings.php");
     include("_functions.php");
     $_language->readModule('forum');
 
-    if (!isforumposter($userID, $_POST['id']) and !isforumadmin($userID) and !ismoderator($userID, $_GET['board'])
+    if (!isforumposter($userID, $_POST['id']) && !isforumadmin($userID) && !ismoderator($userID, $_GET['board'])
     ) {
         die($_language->module['no_accses']);
     }
@@ -212,10 +212,10 @@ if (isset($_POST['newreply']) && !isset($_POST['preview'])) {
         "SELECT postID FROM " . PREFIX . "forum_posts WHERE postID='" . $id .
         "' AND poster='" . $userID . "'"
     ));
-    if (($check or isforumadmin($userID) or ismoderator($userID, (int)$_GET['board'])) and mb_strlen(trim($message))
+    if (($check || isforumadmin($userID) || ismoderator($userID, (int)$_GET['board'])) && mb_strlen(trim($message))
     ) {
 
-        if (isforumadmin($userID) or isanymoderator($userID, $ds['boardID'])) {
+        if (isforumadmin($userID) || isanymoderator($userID, $ds['boardID'])) {
             $do_sticky = (isset($_POST['sticky'])) ? 'sticky=1' : 'sticky=0';
             safe_query(
                 "UPDATE " . PREFIX . "forum_topics SET $do_sticky WHERE topicID='" . (int)$_GET['topic'] .
@@ -240,14 +240,14 @@ if (isset($_POST['newreply']) && !isset($_POST['preview'])) {
         }
     }
     header("Location: index.php?site=forum_topic&topic=" . (int)$_GET['topic'] . "&page=" . (int)$_GET['page']);
-} elseif (isset($_POST['saveedittopic']) and (bool)$_POST['saveedittopic']) {
+} elseif (isset($_POST['saveedittopic']) && (bool)$_POST['saveedittopic']) {
     include("_mysql.php");
     include("_settings.php");
     include("_functions.php");
     $_language->readModule('forum');
 
-    if (!isforumadmin($userID) and
-        !isforumposter($userID, $_POST['post']) and !ismoderator($userID, $_GET['board'])
+    if (!isforumadmin($userID) &&
+        !isforumposter($userID, $_POST['post']) && !ismoderator($userID, $_GET['board'])
     ) {
         die($_language->module['no_accses']);
     }
@@ -272,7 +272,7 @@ if (isset($_POST['newreply']) && !isset($_POST['preview'])) {
             $icon = '';
         }
         $do_sticky = (isset($_POST['sticky'])) ? true : false;
-        if ($do_sticky and (isforumadmin($userID) or isanymoderator($userID, $board))) {
+        if ($do_sticky && (isforumadmin($userID) || isanymoderator($userID, $board))) {
             $do_sticky = true;
         } else {
             $do_sticky = false;
@@ -332,7 +332,7 @@ function showtopic($topic, $edit, $addreply, $quoteID, $type)
     $usergrp = 0;
     $writer = 0;
     $ismod = ismoderator($userID, $dt['boardID']);
-    if ($dt['writegrps'] != "" and !$ismod) {
+    if ($dt['writegrps'] != "" && !$ismod) {
         $writegrps = explode(";", $dt['writegrps']);
         foreach ($writegrps as $value) {
             if (isinusergrp($value, $userID)) {
@@ -344,7 +344,7 @@ function showtopic($topic, $edit, $addreply, $quoteID, $type)
     } else {
         $writer = 1;
     }
-    if ($dt['readgrps'] != "" and !$usergrp and !$ismod) {
+    if ($dt['readgrps'] != "" && !$usergrp && !$ismod) {
         $readgrps = explode(";", $dt['readgrps']);
         foreach ($readgrps as $value) {
             if (isinusergrp($value, $userID)) {
@@ -405,7 +405,7 @@ function showtopic($topic, $edit, $addreply, $quoteID, $type)
         $new = '|';
 
         foreach ($array as $split) {
-            if ($split != "" and $split != $topic) {
+            if ($split != "" && $split != $topic) {
                 $new = $new . $split . '|';
             }
         }
@@ -425,7 +425,7 @@ function showtopic($topic, $edit, $addreply, $quoteID, $type)
 
     $topicactions = '<a href="printview.php?board=' . $dt['boardID'] . '&amp;topic=' . $topic .
         '" target="_blank" class="btn btn-default"><span class="icon-print"></span></a> ';
-    if ($loggedin and $writer) {
+    if ($loggedin && $writer) {
         $topicactions .=
             '<a href="index.php?site=forum&amp;addtopic=true&amp;action=newtopic&amp;board=' . $dt['boardID'] .
             '" class="btn btn-primary hidden">' . $_language->module['new_topic'] .
@@ -463,7 +463,7 @@ function showtopic($topic, $edit, $addreply, $quoteID, $type)
             "SELECT * FROM " . PREFIX . "forum_posts WHERE topicID='" . $dt['topicID'] .
             "' AND postID='" . $id . "' AND poster='" . $userID . "' ORDER BY DATE ASC LIMIT 0,1"
         ));
-        if ($anz or isforumadmin($userID) or ismoderator($userID, $dt['boardID'])) {
+        if ($anz || isforumadmin($userID) || ismoderator($userID, $dt['boardID'])) {
             if (istopicpost($dt['topicID'], $id)) {
                 $bg1 = BG_1;
 
@@ -581,7 +581,7 @@ function showtopic($topic, $edit, $addreply, $quoteID, $type)
             "forum_posts WHERE topicID='$topic' ORDER BY date DESC LIMIT $start, $max"
         );
     } elseif ($addreply && !$dt['closed']) {
-        if ($loggedin and $writer) {
+        if ($loggedin && $writer) {
             if (isset($_POST['preview'])) {
                 $bg1 = BG_1;
                 $bg2 = BG_2;
@@ -614,7 +614,7 @@ function showtopic($topic, $edit, $addreply, $quoteID, $type)
                 } else {
                     $signatur = '';
                 }
-                if ($getemail = getemail($userID) and !getemailhide($userID)) {
+                if ($getemail = getemail($userID) && !getemailhide($userID)) {
                     $email = '<a href="mailto:' . mail_protect($getemail) .
                         '"><img src="images/icons/email.gif" alt="email"></a>';
                 } else {
@@ -791,7 +791,7 @@ function showtopic($topic, $edit, $addreply, $quoteID, $type)
             $signatur = '';
         }
 
-        if ($getemail = getemail($dr['poster']) and !getemailhide($dr['poster'])) {
+        if ($getemail = getemail($dr['poster']) && !getemailhide($dr['poster'])) {
             $email =
                 '<a href="mailto:' . mail_protect($getemail) . '"><img src="images/icons/email.gif" alt="email"></a>';
         } else {
@@ -871,13 +871,13 @@ function showtopic($topic, $edit, $addreply, $quoteID, $type)
         }
 
         $actions = '';
-        if (($userID == $dr['poster'] or isforumadmin($userID) or ismoderator($userID, $dt['boardID'])) &&
+        if (($userID == $dr['poster'] || isforumadmin($userID) || ismoderator($userID, $dt['boardID'])) &&
             !$dt['closed']
         ) {
             $actions = ' <a href="index.php?site=forum_topic&amp;topic=' . $topic . '&amp;edit=true&amp;id=' .
                 $dr['postID'] . '&amp;page=' . $page . '"><span class="icon-edit"></span></a> ';
         }
-        if (isforumadmin($userID) or ismoderator($userID, $dt['boardID'])) {
+        if (isforumadmin($userID) || ismoderator($userID, $dt['boardID'])) {
             $actions .= '<input class="input" type="checkbox" name="postID[]" value="' . $dr['postID'] . '">';
         }
 
@@ -888,7 +888,7 @@ function showtopic($topic, $edit, $addreply, $quoteID, $type)
     }
 
     $adminactions = "";
-    if (isforumadmin($userID) or ismoderator($userID, $dt['boardID'])) {
+    if (isforumadmin($userID) || ismoderator($userID, $dt['boardID'])) {
 
         if ($dt['closed']) {
             $close = '<option value="opentopic">- ' . $_language->module['reopen_topic'] . '</option>';

--- a/gallery.php
+++ b/gallery.php
@@ -143,7 +143,7 @@ if (isset($_POST[ 'saveedit' ])) {
         )
     );
 
-    if ((isgalleryadmin($userID) or $galclass->isGalleryOwner($ds[ 'galleryID' ], $userID)) and $_GET[ 'id' ]) {
+    if ((isgalleryadmin($userID) || $galclass->isGalleryOwner($ds[ 'galleryID' ], $userID)) && $_GET[ 'id' ]) {
 
         $ds = mysqli_fetch_array(
             safe_query(
@@ -256,7 +256,7 @@ if (isset($_POST[ 'saveedit' ])) {
         )
     );
 
-    if ($browse[ 'picID' ] and $_GET[ 'action' ] == "diashow") {
+    if ($browse[ 'picID' ] && $_GET[ 'action' ] == "diashow") {
         echo '<meta http-equiv="refresh" content="2;URL=gallery.php?action=diashow&amp;galleryID=' .
             (int)$_GET[ 'galleryID' ] . '&amp;picID=' . $browse[ 'picID' ] . '">';
     }
@@ -285,7 +285,7 @@ if (isset($_POST[ 'saveedit' ])) {
     echo '<img src="picture.php?id=' . $picID . '" alt=""><br>
     <strong>' . cleartext($ds[ 'comment' ], false) . '</strong>';
 
-    if ($browse[ 'picID' ] or $_GET[ 'action' ] == "window") {
+    if ($browse[ 'picID' ] || $_GET[ 'action' ] == "window") {
         echo '</a>';
     }
 
@@ -448,7 +448,7 @@ if (isset($_POST[ 'saveedit' ])) {
 
         //admin
 
-        if ((isgalleryadmin($userID) and $publicadmin) or $galclass->isGalleryOwner($ds[ 'galleryID' ], $userID)) {
+        if ((isgalleryadmin($userID) && $publicadmin) || $galclass->isGalleryOwner($ds[ 'galleryID' ], $userID)) {
             $adminaction =
                 '<a href="index.php?site=gallery&amp;action=edit&amp;id=' . $_GET[ 'picID' ] .
                 '" class="btn btn-danger">' . $_language->module[ 'edit' ] . '</a>

--- a/guestbook.php
+++ b/guestbook.php
@@ -133,7 +133,7 @@ if (isset($_POST[ 'save' ])) {
     );
 
     header("Location: index.php?site=guestbook");
-} elseif ($action == 'comment' and is_numeric($_GET[ 'guestbookID' ])) {
+} elseif ($action == 'comment' && is_numeric($_GET[ 'guestbookID' ])) {
 
     $_language->readModule('guestbook');
     $_language->readModule('bbcode', true);

--- a/install/functions.php
+++ b/install/functions.php
@@ -1468,12 +1468,12 @@ function update40101_420()
     //news converter
     $q = mysqli_query($_database, "SELECT newsID, lang1, lang2, headline1, headline2, content1, content2 FROM `" . PREFIX . "news`");
     while ($ds = mysqli_fetch_array($q)) {
-        if ($ds['headline1'] != "" or $ds['content1'] != "") {
+        if ($ds['headline1'] != "" || $ds['content1'] != "") {
             if (get_magic_quotes_gpc()) $content1 = str_replace('\r\n', "\n", $ds['content1']);
             else $content1 = str_replace('\r\n', "\n", mysqli_real_escape_string($_database, $ds['content1']));
             mysqli_query($_database, "INSERT INTO " . PREFIX . "news_contents (newsID, language, headline, content) VALUES ('" . $ds['newsID'] . "', '" . mysqli_real_escape_string($_database, $ds['lang1']) . "', '" . mysqli_real_escape_string($_database, $ds['headline1']) . "', '" . $content1 . "')");
         }
-        if ($ds['headline2'] != "" or $ds['content2'] != "") {
+        if ($ds['headline2'] != "" || $ds['content2'] != "") {
             if (get_magic_quotes_gpc()) $content2 = str_replace('\r\n', "\n", $ds['content2']);
             else $content2 = str_replace('\r\n', "\n", mysqli_real_escape_string($_database, $ds['content2']));
             mysqli_query($_database, "INSERT INTO " . PREFIX . "news_contents (newsID, language, headline, content) VALUES ('" . $ds['newsID'] . "', '" . mysqli_real_escape_string($_database, $ds['lang2']) . "', '" . mysqli_real_escape_string($_database, $ds['headline2']) . "', '" . $content2 . "')");

--- a/install/step05.php
+++ b/install/step05.php
@@ -25,7 +25,7 @@
 ##########################################################################
 */
 
-if($_POST['installtype']=="full" AND $_POST['hp_url']) {
+if($_POST['installtype']=="full" && $_POST['hp_url']) {
 ?>
 
   <tr>
@@ -101,7 +101,7 @@ if($_POST['installtype']=="full" AND $_POST['hp_url']) {
      </tr>
    </table>
    <input type="hidden" name="url" value="<?php echo $_POST['hp_url']; ?>">
-   
+
    <?php
    } else echo '<tr>
    <td id="step" align="center" colspan="2">
@@ -121,9 +121,9 @@ if($_POST['installtype']=="full" AND $_POST['hp_url']) {
    <td id="content" colspan="2">
 	'.$_language->module['finish_next'];
    ?>
-   
+
    <input type="hidden" name="installtype" value="<?php echo $_POST['installtype']; ?>">
-	
+
    <div align="right"><br><a href="javascript:document.ws_install.submit()"><img src="images/next.jpg" alt=""></a></div>
    </td>
   </tr>

--- a/joinus.php
+++ b/joinus.php
@@ -95,7 +95,7 @@ if ($action == "save" && isset($_POST['post'])) {
         }
     }
 
-    if (!count($error) and $run) {
+    if (!count($error) && $run) {
         $touser = [];
         $ergebnis =
             safe_query(

--- a/latesttopics.php
+++ b/latesttopics.php
@@ -126,7 +126,7 @@ if ($anz) {
                     break;
                 }
             }
-            if (!$usergrp and !ismoderator($userID, $ds[ 'boardID' ])) {
+            if (!$usergrp && !ismoderator($userID, $ds[ 'boardID' ])) {
                 continue;
             }
         }

--- a/links.php
+++ b/links.php
@@ -250,7 +250,7 @@ if ($action == "new") {
     } else {
         redirect('index.php?site=links', $_language->module[ 'no_access' ]);
     }
-} elseif ($action == "show" and is_numeric($_GET[ 'linkcatID' ])) {
+} elseif ($action == "show" && is_numeric($_GET[ 'linkcatID' ])) {
     if (ispageadmin($userID) || isnewsadmin($userID)) {
         echo
             '<a href="index.php?site=links&amp;action=new" class="btn btn-danger">' .

--- a/login.php
+++ b/login.php
@@ -37,7 +37,7 @@ if ($loggedin) {
     } else {
         $admin = '';
     }
-    if (isclanmember($userID) or iscashadmin($userID)) {
+    if (isclanmember($userID) || iscashadmin($userID)) {
         $cashbox = '<li><a href="index.php?site=cashbox" class="alert-danger">' . $_language->module[ 'cash-box' ] .
             '</a></li><li class="divider"></li>';
     } else {

--- a/loginoverview.php
+++ b/loginoverview.php
@@ -119,7 +119,7 @@ if ($userID && !isset($_GET[ 'userID' ]) && !isset($_POST[ 'userID' ])) {
                         break;
                     }
                 }
-                if (!$usergrp and !ismoderator($userID, $db[ 'boardID' ])) {
+                if (!$usergrp && !ismoderator($userID, $db[ 'boardID' ])) {
                     continue;
                 }
             }
@@ -156,7 +156,7 @@ if ($userID && !isset($_GET[ 'userID' ]) && !isset($_POST[ 'userID' ])) {
                         break;
                     }
                 }
-                if (!$usergrp and !ismoderator($userID, $db[ 'boardID' ])) {
+                if (!$usergrp && !ismoderator($userID, $db[ 'boardID' ])) {
                     continue;
                 }
             }

--- a/messenger.php
+++ b/messenger.php
@@ -79,7 +79,7 @@ if (isset($_POST['delete'])) {
     $_language->readModule('messenger');
 
     $touser = $_POST['touser'];
-    if ($touser[0] == "" and $_POST['touser_field'] != "*") {
+    if ($touser[0] == "" && $_POST['touser_field'] != "*") {
         $tmp = explode(",", $_POST['touser_field']);
         for ($i = 0; $i < 5; $i++) {
             if (isset($tmp[$i])) {
@@ -119,7 +119,7 @@ if (isset($_POST['delete'])) {
         $title = $_POST['title'];
     }
     $message = $_POST['message'];
-    if ($touser[0] != "" and isset($userID)) {
+    if ($touser[0] != "" && isset($userID)) {
         foreach ($touser as $id) {
             sendmessage($id, $title, $message, $userID);
         }
@@ -186,7 +186,7 @@ if (isset($_POST['delete'])) {
             }
         }
 
-        if (isset($entries) and $entries > 0) {
+        if (isset($entries) && $entries > 0) {
             $max = (int)$entries;
         } else {
             $max = $maxmessages;
@@ -349,7 +349,7 @@ if (isset($_POST['delete'])) {
                 $type = 'ASC';
             }
         }
-        if (isset($entries) and $entries > 0) {
+        if (isset($entries) && $entries > 0) {
             $max = (int)$entries;
         } else {
             $max = $maxmessages;
@@ -491,7 +491,7 @@ if (isset($_POST['delete'])) {
             )
         );
 
-        if ($ds['touser'] == $userID or $ds['fromuser'] == $userID) {
+        if ($ds['touser'] == $userID || $ds['fromuser'] == $userID) {
             safe_query("UPDATE " . PREFIX . "messenger SET viewed='1' WHERE messageID='$id'");
             $date = getformatdatetime($ds['date']);
             $sender = '<a href="index.php?site=profile&amp;id=' . $ds['fromuser'] . '"><b>' .
@@ -523,7 +523,7 @@ if (isset($_POST['delete'])) {
         $_language->readModule('bbcode', true);
         $ergebnis = safe_query("SELECT * FROM " . PREFIX . "messenger WHERE messageID='$id'");
         $ds = mysqli_fetch_array($ergebnis);
-        if ($ds['touser'] == $userID or $ds['fromuser'] == $userID) {
+        if ($ds['touser'] == $userID || $ds['fromuser'] == $userID) {
             $replytouser = $ds['fromuser'];
             $tousernick = getnickname($replytouser);
             $date = getformatdatetime($ds['date']);

--- a/myprofile.php
+++ b/myprofile.php
@@ -88,7 +88,7 @@ if (!$userID) {
 
         $error_array = [];
 
-        if (isset($_POST['userID']) or isset($_GET['userID']) or $userID == "") {
+        if (isset($_POST['userID']) || isset($_GET['userID']) || $userID == "") {
             die($_language->module['not_logged_in']);
         }
 
@@ -121,7 +121,7 @@ if (!$userID) {
 
         //avatar
         $filepath = "./images/avatars/";
-        if ($avatar['name'] != "" or ($_POST['avatar_url'] != "" and $_POST['avatar_url'] != "http://")) {
+        if ($avatar['name'] != "" || ($_POST['avatar_url'] != "" && $_POST['avatar_url'] != "http://")) {
             if ($avatar['name'] != "") {
                 move_uploaded_file($avatar['tmp_name'], $filepath . $avatar['name'] . ".tmp");
             } else {
@@ -170,7 +170,7 @@ if (!$userID) {
 
         //userpic
         $filepath = "./images/userpics/";
-        if ($userpic['name'] != "" or ($_POST['userpic_url'] != "" and $_POST['userpic_url'] != "http://")) {
+        if ($userpic['name'] != "" || ($_POST['userpic_url'] != "" && $_POST['userpic_url'] != "http://")) {
             if ($userpic['name'] != "") {
                 move_uploaded_file($userpic['tmp_name'], $filepath . $userpic['name'] . ".tmp");
             } else {
@@ -287,7 +287,7 @@ if (!$userID) {
         }
     }
 
-    if (isset($_GET['action']) and $_GET['action'] == "editpwd") {
+    if (isset($_GET['action']) && $_GET['action'] == "editpwd") {
 
         $bg1 = BG_1;
         $bg2 = BG_2;
@@ -337,7 +337,7 @@ if (!$userID) {
             echo '<strong>ERROR: ' . $error . '</strong><br><br>
                 <input type="button" onclick="javascript:history.back()" value="' . $_language->module['back'] . '">';
         }
-    } elseif (isset($_GET['action']) and $_GET['action'] == "editmail") {
+    } elseif (isset($_GET['action']) && $_GET['action'] == "editmail") {
 
         $bg1 = BG_1;
         $bg2 = BG_2;
@@ -569,7 +569,7 @@ if (!$userID) {
             $langs = [];
             if ($dh = opendir($filepath)) {
                 while ($file = mb_substr(readdir($dh), 0, 2)) {
-                    if ($file != "." and $file != ".." and is_dir($filepath . $file)) {
+                    if ($file != "." && $file != ".." && is_dir($filepath . $file)) {
                         if (isset($mysql_langs[$file])) {
                             $name = $mysql_langs[$file];
                             $name = ucfirst($name);

--- a/news.php
+++ b/news.php
@@ -145,7 +145,7 @@ if ($action == "new") {
                 newsID = '" . (int)$newsID ."'"
         )
     );
-    if (($ds[ 'poster' ] != $userID or !isnewswriter($userID)) and !isnewsadmin($userID)) {
+    if (($ds[ 'poster' ] != $userID || !isnewswriter($userID)) && !isnewsadmin($userID)) {
         die($_language->module[ 'no_access' ]);
     }
 
@@ -263,7 +263,7 @@ if ($action == "new") {
     if (isset($_POST[ 'topnews' ])) {
         if ($_POST[ 'topnews' ]) {
             safe_query("UPDATE " . PREFIX . "settings SET topnewsID='" . $newsID . "'");
-        } elseif (!$_POST[ 'topnews' ] and $newsID == $topnewsID) {
+        } elseif (!$_POST[ 'topnews' ] && $newsID == $topnewsID) {
             safe_query("UPDATE " . PREFIX . "settings SET topnewsID='0'");
         }
     }
@@ -288,7 +288,7 @@ if ($action == "new") {
     $result = safe_query("SELECT * FROM " . PREFIX . "news WHERE newsID='$newsID'");
     $ds = mysqli_fetch_array($result);
 
-    if (($ds[ 'poster' ] != $userID or !isnewswriter($userID)) and !isnewsadmin($userID)) {
+    if (($ds[ 'poster' ] != $userID || !isnewswriter($userID)) && !isnewsadmin($userID)) {
         die($_language->module[ 'no_access' ]);
     }
 
@@ -467,7 +467,7 @@ if ($action == "new") {
                         newsID='" . (int)$id ."'"
                 )
             );
-            if (($ds[ 'poster' ] != $userID or !isnewswriter($userID)) and !isnewsadmin($userID)) {
+            if (($ds[ 'poster' ] != $userID || !isnewswriter($userID)) && !isnewsadmin($userID)) {
                 die($_language->module[ 'no_access' ]);
             }
             if ($ds[ 'screens' ]) {
@@ -510,7 +510,7 @@ if ($action == "new") {
               newsID='" . (int)$id ."'"
         )
     );
-    if (($ds[ 'poster' ] != $userID or !isnewswriter($userID)) and !isnewsadmin($userID)) {
+    if (($ds[ 'poster' ] != $userID || !isnewswriter($userID)) && !isnewsadmin($userID)) {
         die($_language->module[ 'no_access' ]);
     }
     if ($ds[ 'screens' ]) {
@@ -546,7 +546,7 @@ if ($action == "new") {
     $newsID = $_GET[ 'newsID' ];
 
     $ds = mysqli_fetch_array(safe_query("SELECT * FROM " . PREFIX . "news WHERE newsID='" . $newsID . "'"));
-    if (($ds[ 'poster' ] != $userID or !isnewswriter($userID)) and !isnewsadmin($userID)) {
+    if (($ds[ 'poster' ] != $userID || !isnewswriter($userID)) && !isnewsadmin($userID)) {
         die($_language->module[ 'no_access' ]);
     }
 
@@ -1218,7 +1218,7 @@ if ($action == "new") {
                 '<a href="news.php?quickactiontype=unpublish&amp;newsID=' . $ds[ 'newsID' ] .
                 '" class="btn btn-danger">' . $_language->module[ 'unpublish' ] . '</a>';
         }
-        if ((isnewswriter($userID) and $ds[ 'poster' ] == $userID) or isnewsadmin($userID)) {
+        if ((isnewswriter($userID) && $ds[ 'poster' ] == $userID) || isnewsadmin($userID)) {
             $adminaction .=
                 '<input type="button" onclick="window.open(\'news.php?action=edit&amp;newsID=' . $ds[ 'newsID' ] .
                 '\',\'News\',\'toolbar=no,status=no,scrollbars=yes,width=800,height=600\');" value="' .

--- a/news_comments.php
+++ b/news_comments.php
@@ -174,7 +174,7 @@ if ($newsID) {
             $related = "n/a";
         }
 
-        if (isnewsadmin($userID) or (isnewswriter($userID) and $ds[ 'poster' ] == $userID)) {
+        if (isnewsadmin($userID) || (isnewswriter($userID) && $ds[ 'poster' ] == $userID)) {
             $adminaction =
                 '<input type="button" onclick="window.open(
                         \'news.php?action=edit&amp;newsID=' . $ds[ 'newsID' ] . '\',

--- a/poll.php
+++ b/poll.php
@@ -116,7 +116,7 @@ function vote($poll)
             $cookie = in_array($ds[ 'pollID' ], $_COOKIE[ 'poll' ]);
         }
 
-        if ($cookie or $anz or $anz_user) {
+        if ($cookie || $anz || $anz_user) {
 
             if ($ds[ 'intern' ] == 1) {
                 $isintern = '(' . $_language->module[ 'intern' ] . ')';

--- a/polls.php
+++ b/polls.php
@@ -80,7 +80,7 @@ if ($action == "vote") {
         if (isset($_COOKIE[ 'poll' ]) && is_array($_COOKIE[ 'poll' ])) {
             $cookie = in_array($pollID, $_COOKIE[ 'poll' ]);
         }
-        if (!$cookie and !$anz and !$anz_user and isset($_POST[ 'vote' ])) {
+        if (!$cookie && !$anz && !$anz_user && isset($_POST[ 'vote' ])) {
 
             //write cookie
             $index = count($_COOKIE[ 'poll' ]);
@@ -558,7 +558,7 @@ if ($action == "new") {
             $cookie = in_array($ds[ 'pollID' ], $_COOKIE[ 'poll' ]);
         }
 
-        if ($cookie or $anz or $anz_user) {
+        if ($cookie || $anz || $anz_user) {
             redirect('index.php?site=polls&amp;pollID=' . $ds[ 'pollID' ], $_language->module[ 'already_voted' ], 3);
         } else {
             echo '<form method="post" action="polls.php?action=vote">
@@ -632,7 +632,7 @@ if ($action == "new") {
                 $isintern = '';
             }
 
-            if ($ds[ 'laufzeit' ] < time() or $ds[ 'aktiv' ] == "0") {
+            if ($ds[ 'laufzeit' ] < time() || $ds[ 'aktiv' ] == "0") {
                 $timeleft = $_language->module[ 'poll_ended' ];
                 $active = '';
             } else {

--- a/printview.php
+++ b/printview.php
@@ -74,7 +74,7 @@ if (mysqli_num_rows($thread)) {
                 break;
             }
         }
-        if (!$usergrp and !ismoderator($userID, $dt[ 'boardID' ])) {
+        if (!$usergrp && !ismoderator($userID, $dt[ 'boardID' ])) {
             die($_language->module[ 'no_access' ]);
         }
     }

--- a/profile.php
+++ b/profile.php
@@ -38,7 +38,7 @@ if (isset($_GET[ 'action' ])) {
     $action = '';
 }
 
-if (isset($id) and getnickname($id) != '') {
+if (isset($id) && getnickname($id) != '') {
 
     if (isbanned($id)) {
         $banned =
@@ -260,7 +260,7 @@ if (isset($id) and getnickname($id) != '') {
                             break;
                         }
                     }
-                    if (!$usergrp and !ismoderator($userID, $db[ 'boardID' ])) {
+                    if (!$usergrp && !ismoderator($userID, $db[ 'boardID' ])) {
                         continue;
                     }
                 }
@@ -328,7 +328,7 @@ if (isset($id) and getnickname($id) != '') {
                             break;
                         }
                     }
-                    if (!$usergrp and !ismoderator($userID, $db[ 'boardID' ])) {
+                    if (!$usergrp && !ismoderator($userID, $db[ 'boardID' ])) {
                         continue;
                     }
                 }
@@ -456,7 +456,7 @@ if (isset($id) and getnickname($id) != '') {
                     }
                     redirect('index.php?site=profile&amp;id=' . $id . '&amp;action=guestbook', '', 0);
                 } elseif (isset($_GET[ 'delete' ])) {
-                    if (!isanyadmin($userID) and $id != $userID) {
+                    if (!isanyadmin($userID) && $id != $userID) {
                         die($_language->module[ 'no_access' ]);
                     }
 

--- a/report.php
+++ b/report.php
@@ -40,7 +40,7 @@ if ($userID) {
     }
 }
 
-if ($_POST[ 'mode' ] and $run) {
+if ($_POST[ 'mode' ] && $run) {
     $mode = $_POST[ 'mode' ];
     $type = $_POST[ 'type' ];
     $info = $_POST[ 'description' ];

--- a/sc_headlines.php
+++ b/sc_headlines.php
@@ -25,7 +25,7 @@
 ##########################################################################
 */
 
-if (isset($rubricID) and $rubricID) {
+if (isset($rubricID) && $rubricID) {
     $only = "AND rubric='" . $rubricID . "'";
 } else {
     $only = '';

--- a/sc_language.php
+++ b/sc_language.php
@@ -62,7 +62,7 @@ if (isset($_GET[ 'new_lang' ])) {
 
     if ($dh = opendir($filepath)) {
         while ($file = mb_substr(readdir($dh), 0, 2)) {
-            if ($file != "." and $file != ".." and is_dir($filepath . $file)) {
+            if ($file != "." && $file != ".." && is_dir($filepath . $file)) {
                 if (isset($mysql_langs[ $file ])) {
                     $name = $mysql_langs[ $file ];
                     $name = ucfirst($name);

--- a/search.php
+++ b/search.php
@@ -56,7 +56,7 @@ if (
         echo $title_search;
 
         $text = str_replace(['%', '*'], ['\%', '%'], $_REQUEST[ 'text' ]);
-        if (!isset($_REQUEST[ 'r' ]) or $_REQUEST[ 'r' ] < 1 or $_REQUEST[ 'r' ] > 100) {
+        if (!isset($_REQUEST[ 'r' ]) || $_REQUEST[ 'r' ] < 1 || $_REQUEST[ 'r' ] > 100) {
             $results = 50;
         } else {
             $results = (int)$_REQUEST[ 'r' ];
@@ -244,7 +244,7 @@ if (
                                 break;
                             }
                         }
-                        if (!$usergrp and !ismoderator($userID, $ds[ 'boardID' ])) {
+                        if (!$usergrp && !ismoderator($userID, $ds[ 'boardID' ])) {
                             continue;
                         }
                     }
@@ -376,7 +376,7 @@ if (
 
             $i = 0;
             foreach ($res_occurr as $key => $val) {
-                if ($page > 1 and $i < ($results * ($page - 1))) {
+                if ($page > 1 && $i < ($results * ($page - 1))) {
                     $i++;
                     continue;
                 }

--- a/squads.php
+++ b/squads.php
@@ -119,7 +119,7 @@ if ($action == "show") {
                 $userdescription = $_language->module[ 'no_description' ];
             }
 
-            if ($dm[ 'userpic' ] != "" and file_exists("images/userpics/" . $dm[ 'userpic' ])) {
+            if ($dm[ 'userpic' ] != "" && file_exists("images/userpics/" . $dm[ 'userpic' ])) {
                 $userpic = $dm[ 'userpic' ];
                 $pic_info = $dm[ 'nickname' ] . ' ' . $_language->module[ 'userpicture' ];
             } else {

--- a/src/func/language.php
+++ b/src/func/language.php
@@ -43,7 +43,7 @@ class Language
 
         if ($dh = opendir($filepath)) {
             while ($file = mb_substr(readdir($dh), 0, 2)) {
-                if ($file != "." and $file != ".." and is_dir($filepath . $file)) {
+                if ($file != "." && $file != ".." && is_dir($filepath . $file)) {
                     $langs[] = $file;
                 }
             }

--- a/src/func/tags.php
+++ b/src/func/tags.php
@@ -137,7 +137,7 @@ class Tags
                 (
                     isnewsadmin($userID) ||
                     (
-                        isnewswriter($userID) and $ds['poster'] == $userID
+                        isnewswriter($userID) && $ds['poster'] == $userID
                     )
                 )
             )

--- a/src/login.php
+++ b/src/login.php
@@ -37,7 +37,7 @@ if (isset($_SESSION['ws_auth'])) {
         $ws_user = $authent[0];
         $ws_pwd = $authent[1];
 
-        if (isset($ws_user) and isset($ws_pwd)) {
+        if (isset($ws_user) && isset($ws_pwd)) {
             $check = safe_query(
                 "SELECT
                     userID, language


### PR DESCRIPTION
Explanation of the problem:
http://stackoverflow.com/questions/2803321/and-vs-as-operator

<!---
@huboard:{"order":61.0,"milestone_order":117,"custom_state":""}
-->
