### PR TITLE
Compress Source as Archive on release

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -250,13 +250,13 @@ module.exports = function(grunt) {
         compress: {
             main: {
                 options: {
-                    archive: 'webspell.zip'
+                    archive: "webspell.zip"
                 },
                 src:releaseFiles
             },
             release: {
                 options: {
-                    archive: 'webSPELL-<%= pkg.version %>.zip'
+                    archive: "webSPELL-<%= pkg.version %>.zip"
                 },
                 src:releaseFiles
             }
@@ -281,7 +281,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks("grunt-htmllint");
     grunt.loadNpmTasks("grunt-casperjs");
     grunt.loadNpmTasks("grunt-newer");
-    grunt.loadNpmTasks('grunt-contrib-compress');
+    grunt.loadNpmTasks("grunt-contrib-compress");
 
 
     grunt.registerTask("codecheck", [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,6 +20,37 @@ module.exports = function(grunt) {
             "!languages/**/*.php",
             "!index.php"
         ],
+        releaseFiles = [
+            "admin/**",
+            "demos/**",
+            "downloads/**",
+            "images/**",
+            "install/**",
+            "js/**",
+            "languages/**",
+            "!languages/check_translations.php",
+            "src/**",
+            "templates/**",
+            "tmp/**",
+            "*",
+            "!.gitignore",
+            "!.scrutinizer*",
+            "!.sensiolabs.yml",
+            "!.travis.yml",
+            "!.bowerrc",
+            "!.htmllintrc",
+            "!.htmlhintrc",
+            "!.jshintrc",
+            "!circle.yml",
+            "!Gruntfile.js",
+            "!grunt-log.txt",
+            "!*.zip",
+            "!Ruleset.xml",
+            "!vendor",
+            "!components",
+            "!node_modules",
+            "!tests"
+        ],
         csss = [ "**/*.css" ],
         excludes = [
             "!node_modules/**",
@@ -215,6 +246,20 @@ module.exports = function(grunt) {
                     "js"
                 ]
             }
+        },
+        compress: {
+            main: {
+                options: {
+                    archive: 'webspell.zip'
+                },
+                src:releaseFiles
+            },
+            release: {
+                options: {
+                    archive: 'webSPELL-<%= pkg.version %>.zip'
+                },
+                src:releaseFiles
+            }
         }
     });
 
@@ -236,6 +281,8 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks("grunt-htmllint");
     grunt.loadNpmTasks("grunt-casperjs");
     grunt.loadNpmTasks("grunt-newer");
+    grunt.loadNpmTasks('grunt-contrib-compress');
+
 
     grunt.registerTask("codecheck", [
         "js",
@@ -296,10 +343,12 @@ module.exports = function(grunt) {
                 "replace:copyright",
                 "replace:version",
                 "changelog",
-                "bumpCommit:" + releaseLevel
+                "bumpCommit:" + releaseLevel,
+                "compress:release"
             ]);
         }
     });
+
     grunt.registerTask("bumpOnly", function() {
         grunt.config("bump", {
             options: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -283,7 +283,6 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks("grunt-newer");
     grunt.loadNpmTasks("grunt-contrib-compress");
 
-
     grunt.registerTask("codecheck", [
         "js",
         "php",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "grunt-bump": "0.0.16",
     "grunt-casperjs": "^2.1.0",
     "grunt-cli": "^0.1.3",
+    "grunt-contrib-compress": "^0.13.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-githooks": "^0.3.1",


### PR DESCRIPTION
fixes #97
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/124%23issuecomment-69166195%22%2C%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/124%23issuecomment-69167791%22%2C%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/124%23issuecomment-69168877%22%2C%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/124%23issuecomment-69808298%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/124%23issuecomment-69166195%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20think%20it%27s%20preferable%20to%20go%20for%20a%20blacklist%20instead%20of%20a%20mixed%20white%20/%20blacklist.%5Cr%5Cn%5Cr%5Cn%60%60%60php%5Cr%5CnreleaseFiles%20%3D%20%5B%5Cr%5Cn%5C%22%2A/%2A%2A%5C%22%2C%5Cr%5Cn%5C%22%21...%5C%22%2C%5Cr%5Cn%5C%22%21...%5C%22%2C%5Cr%5Cn...%5Cr%5Cn%5D%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-01-08T11%3A14%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/498197%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Pascalmh%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20much%20slower%20when%20it%20is%20only%20a%20blacklist%22%2C%20%22created_at%22%3A%20%222015-01-08T11%3A30%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415280%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Phhere%22%7D%7D%2C%20%7B%22body%22%3A%20%22Still%20think%20that%20a%20blacklist%20is%20easier%20to%20maintain%20and%20performance%20is%20not%20an%20issue%20for%20that%20task%20as%20it%20is%20not%20used%20that%20often.%22%2C%20%22created_at%22%3A%20%222015-01-08T11%3A41%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/498197%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Pascalmh%22%7D%7D%2C%20%7B%22body%22%3A%20%22Files%20we%20actually%20use%20have%20to%20be%20transferred%20into%20another%20folder%20before%20we%20release%20%60/components/%60%20will%20not%20be%20included%20in%20the%20release.%22%2C%20%22created_at%22%3A%20%222015-01-13T19%3A55%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/498197%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Pascalmh%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/webSPELL/webSPELL-4.2.3/pull/124#issuecomment-69166195'>General Comment</a></b>
- <a href='https://github.com/Pascalmh'><img border=0 src='https://avatars.githubusercontent.com/u/498197?v=3' height=16 width=16'></a> I think it's preferable to go for a blacklist instead of a mixed white / blacklist.
```php
releaseFiles = [
"*/**",
"!...",
"!...",
...
]
```
- <a href='https://github.com/Phhere'><img border=0 src='https://avatars.githubusercontent.com/u/1415280?v=3' height=16 width=16'></a> It is much slower when it is only a blacklist
- <a href='https://github.com/Pascalmh'><img border=0 src='https://avatars.githubusercontent.com/u/498197?v=3' height=16 width=16'></a> Still think that a blacklist is easier to maintain and performance is not an issue for that task as it is not used that often.
- <a href='https://github.com/Pascalmh'><img border=0 src='https://avatars.githubusercontent.com/u/498197?v=3' height=16 width=16'></a> Files we actually use have to be transferred into another folder before we release `/components/` will not be included in the release.


<a href='https://www.codereviewhub.com/webSPELL/webSPELL-4.2.3/pull/124?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/webSPELL/webSPELL-4.2.3/pull/124?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/webSPELL/webSPELL-4.2.3/pull/124'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>