### PR TITLE
Checklogin - Replace Error Message #119 with bootstrap style

### DIFF
--- a/_stylesheet.css
+++ b/_stylesheet.css
@@ -118,3 +118,32 @@ a.flag.active img, a.flag:hover img {
     overflow: hidden;
     text-align: left;
 }
+
+/* Centers on login error message */
+.checklogin-html {
+   height: 100%;
+}
+
+.checklogin-body {
+   padding:0;			   /* Reset paddings, to remove top-padding set in _stylesheet  */
+   display: -webkit-box;   /* OLD: Safari,  iOS, Android browser, older WebKit browsers.  */
+   display: -moz-box;      /* OLD: Firefox (buggy) */
+   display: -ms-flexbox;   /* MID: IE 10 */
+   display: -webkit-flex;  /* NEW, Chrome 21–28, Safari 6.1+ */
+   display: flex;          /* NEW: IE11, Chrome 29+, Opera 12.1+, Firefox 22+ */
+
+   /* OLD… */
+   -webkit-box-align: center; -moz-box-align: center;
+   -ms-flex-align: center;
+   -webkit-align-items: center;
+   align-items: center;
+
+   -webkit-box-pack: center; -moz-box-pack: center;
+   -ms-flex-pack: center;
+   -webkit-justify-content: center;
+   justify-content: center;
+
+   margin: 0;
+   height: 100%;
+   width: 100% /* needed for Firefox */
+}

--- a/checklogin.php
+++ b/checklogin.php
@@ -199,12 +199,10 @@ if ($login) {
 }
     ?>
     <link href="_stylesheet.css" rel="stylesheet">
-	
     </head>
     <body class="checklogin-body">
 	<div class="alert alert-danger text-center" role="alert"><?php echo $error; ?></div>
 	</body>
-
     </html>
     <?php
 }

--- a/checklogin.php
+++ b/checklogin.php
@@ -182,7 +182,7 @@ if ($login) {
 } else {
     ?>
     <!DOCTYPE html>
-    <html>
+    <html class="checklogin-html">
     <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="utf-8">
@@ -199,37 +199,12 @@ if ($login) {
 }
     ?>
     <link href="_stylesheet.css" rel="stylesheet">
-	<style>
-		html, body{
-			height:100%; margin:0;padding:0
-			}
-
-		.container-fluid{
-			height:100%;
-			display:table;
-			width: 100%;
-			padding: 0;
-			}
-
-		.row-fluid {
-			height: 100%; 
-			display:table-cell; 
-			vertical-align: middle;
-			}
-
-		.centering {
-			float:none;
-			margin:0 auto;
-			}
-	</style>
+	
     </head>
-    <body>
-	<div class="container-fluid">
-    <div class="row-fluid">
-       <div class="alert alert-danger centering text-center" role="alert"><?php echo $error; ?><div>
-    </div>
-	</div>
-    </body>
+    <body class="checklogin-body">
+	<div class="alert alert-danger text-center" role="alert"><?php echo $error; ?></div>
+	</body>
+
     </html>
     <?php
 }

--- a/checklogin.php
+++ b/checklogin.php
@@ -181,27 +181,27 @@ if ($login) {
     header("Location: index.php?site=loginoverview");
 } else {
     ?>
-	<!DOCTYPE html>
-	<html class="checklogin-html">
-	<head>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta charset="utf-8">
-	<meta name="description" content="Clanpage using webSPELL 4 CMS">
-	<meta name="author" content="webspell.org">
-	<meta name="keywords" content="webspell, webspell4, clan, cms">
-	<meta name="generator" content="webSPELL">
-	<!-- Head & Title include -->
-	<title><?php echo PAGETITLE; ?></title>
-	<base href="<?php echo $rewriteBase; ?>">
-	<?php foreach ($components['css'] as $component) {
-	echo '<link href="' . $component . '" rel="stylesheet">';
-	}
-	?>
-	<link href="_stylesheet.css" rel="stylesheet">
-	</head>
-	<body class="checklogin-body">
-	<div class="alert alert-danger text-center" role="alert"><?php echo $error; ?></div>
-	</body>
-	</html>
-	<?php
+<!DOCTYPE html>
+<html class="checklogin-html">
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta charset="utf-8">
+        <meta name="description" content="Clanpage using webSPELL 4 CMS">
+        <meta name="author" content="webspell.org">
+        <meta name="keywords" content="webspell, webspell4, clan, cms">
+        <meta name="generator" content="webSPELL">
+        <!-- Head & Title include -->
+        <title><?php echo PAGETITLE; ?></title>
+        <base href="<?php echo $rewriteBase; ?>">
+        <?php foreach ($components['css'] as $component) {
+        echo '<link href="' . $component . '" rel="stylesheet">';
+    }
+        ?>
+        <link href="_stylesheet.css" rel="stylesheet">
+    </head>
+    <body class="checklogin-body">
+        <div class="alert alert-danger text-center" role="alert"><?php echo $error; ?></div>
+    </body>
+</html>
+<?php
 }

--- a/checklogin.php
+++ b/checklogin.php
@@ -184,29 +184,51 @@ if ($login) {
     <!DOCTYPE html>
     <html>
     <head>
-        <meta charset="utf-8">
-        <meta name="description" content="Clanpage using webSPELL 4 CMS">
-        <meta name="author" content="webspell.org">
-        <meta name="keywords" content="webspell, webspell4, clan, cms">
-        <meta name="copyright" content="Copyright 2005-2014 by webspell.org">
-        <meta name="generator" content="webSPELL">
-        <title><?php echo PAGETITLE; ?></title>
-        <link href="_stylesheet.css" rel="stylesheet" type="text/css">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8">
+    <meta name="description" content="Clanpage using webSPELL 4 CMS">
+    <meta name="author" content="webspell.org">
+    <meta name="keywords" content="webspell, webspell4, clan, cms">
+    <meta name="generator" content="webSPELL">
+
+    <!-- Head & Title include -->
+    <title><?php echo PAGETITLE; ?></title>
+    <base href="<?php echo $rewriteBase; ?>">
+    <?php foreach ($components['css'] as $component) {
+        echo '<link href="' . $component . '" rel="stylesheet">';
+}
+    ?>
+    <link href="_stylesheet.css" rel="stylesheet">
+	<style>
+		html, body{
+			height:100%; margin:0;padding:0
+			}
+
+		.container-fluid{
+			height:100%;
+			display:table;
+			width: 100%;
+			padding: 0;
+			}
+
+		.row-fluid {
+			height: 100%; 
+			display:table-cell; 
+			vertical-align: middle;
+			}
+
+		.centering {
+			float:none;
+			margin:0 auto;
+			}
+	</style>
     </head>
     <body>
-    <table class="table">
-        <tr>
-            <td height="500" class="text-center">
-                <table width="350" border="0" cellpadding="10" cellspacing="0" style="border:1px solid <?php
-                    echo BORDER; ?>" bgcolor="<?php
-                        echo BG_1; ?>">
-                    <tr>
-                        <td class="text-center"><?php echo $error; ?></td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
-    </table>
+	<div class="container-fluid">
+    <div class="row-fluid">
+       <div class="alert alert-danger centering text-center" role="alert"><?php echo $error; ?><div>
+    </div>
+	</div>
     </body>
     </html>
     <?php

--- a/checklogin.php
+++ b/checklogin.php
@@ -181,28 +181,27 @@ if ($login) {
     header("Location: index.php?site=loginoverview");
 } else {
     ?>
-    <!DOCTYPE html>
-    <html class="checklogin-html">
-    <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta charset="utf-8">
-    <meta name="description" content="Clanpage using webSPELL 4 CMS">
-    <meta name="author" content="webspell.org">
-    <meta name="keywords" content="webspell, webspell4, clan, cms">
-    <meta name="generator" content="webSPELL">
-
-    <!-- Head & Title include -->
-    <title><?php echo PAGETITLE; ?></title>
-    <base href="<?php echo $rewriteBase; ?>">
-    <?php foreach ($components['css'] as $component) {
-        echo '<link href="' . $component . '" rel="stylesheet">';
-}
-    ?>
-    <link href="_stylesheet.css" rel="stylesheet">
-    </head>
-    <body class="checklogin-body">
+	<!DOCTYPE html>
+	<html class="checklogin-html">
+	<head>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta charset="utf-8">
+	<meta name="description" content="Clanpage using webSPELL 4 CMS">
+	<meta name="author" content="webspell.org">
+	<meta name="keywords" content="webspell, webspell4, clan, cms">
+	<meta name="generator" content="webSPELL">
+	<!-- Head & Title include -->
+	<title><?php echo PAGETITLE; ?></title>
+	<base href="<?php echo $rewriteBase; ?>">
+	<?php foreach ($components['css'] as $component) {
+	echo '<link href="' . $component . '" rel="stylesheet">';
+	}
+	?>
+	<link href="_stylesheet.css" rel="stylesheet">
+	</head>
+	<body class="checklogin-body">
 	<div class="alert alert-danger text-center" role="alert"><?php echo $error; ?></div>
 	</body>
-    </html>
-    <?php
+	</html>
+	<?php
 }


### PR DESCRIPTION
I changed it with a boostrap 'Alert' style message.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/130%23issuecomment-69452906%22%2C%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/130%23issuecomment-69456628%22%2C%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/130%23issuecomment-69456945%22%2C%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/130%23issuecomment-69464265%22%2C%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/130%23issuecomment-69482268%22%2C%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/130%23issuecomment-69544517%22%2C%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/130%23issuecomment-69544688%22%2C%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/130%23issuecomment-69544903%22%2C%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/130%23issuecomment-70016350%22%2C%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/130%23issuecomment-70369968%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/webSPELL/webSPELL-4.2.3/pull/130%23issuecomment-69452906%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20add%20inline%20CSS%20for%20this%3F%5Cr%5CnIt%20only%20needs%20the%20Bootstrap%20includes.%22%2C%20%22created_at%22%3A%20%222015-01-10T11%3A38%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/706758%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/derchrisuk%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20inline%20css%20is%20used%2C%20to%20display%20it%20vertically%20in%20the%20middle%20of%20your%20browser.%5Cr%5CnElse%20it%20would%20be%20at%20the%20top%20of%20the%20page%2C%20and%20it%20didn%27t%20really%20look%20nice%20imo.%5Cr%5CnI%20have%20no%20idea%2C%20how%20to%20archieve%20this%20in%20any%20other%20way.%20Without%20altering%20some%20properties%20trough%20inline%20css.%22%2C%20%22created_at%22%3A%20%222015-01-10T13%3A58%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7575436%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DDaems%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20are%20not%20using%20the%20fluid%20grid%20anywhere%20else%20-%20this%20should%20be%20switched%20to%20the%20static%20grid.%5Cr%5CnInstead%20of%20using%20inline%20style%20put%20this%20stuff%20into%20the%20_stylesheet%2C%20however%20I%20don%27t%20think%20we%20need%20to%20alter%20any%20Bootstrap%20CSS%20at%20this%20point.%5Cr%5Cn%5Cr%5CnI%20think%20we%20can%20use%20%5BFlexbox%5D%28http%3A//caniuse.com/%23search%3Dflexbox%29%20here%20-%20see%3A%20http%3A//stackoverflow.com/questions/20547819/vertical-align-with-bootstrap-3/25517025%2325517025%22%2C%20%22created_at%22%3A%20%222015-01-10T14%3A08%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/498197%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Pascalmh%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20tried%20flexbox%2C%20but%20had%20some%20troubles%20getting%20the%20alertbox%20horizontal%20centered.%5Cr%5CnThats%20the%20reason%20why%20i%20went%20with%20a%20alternavite%20approach.%5Cr%5CnBut%20i%27ll%20try%20it%20again%20with%20the%20link%20u%20provided..%5Cr%5Cn%5Cr%5CnI%20used%20fluid%2C%20to%20have%20the%20alert%20message%20box%20reach%20the%20side%20of%20the%20browser.%5Cr%5CnThough%20it%20has%20a%20nicer%20appeal%20to%20it.%5Cr%5Cn%5Cr%5CnI%27ll%20update%20it%20as%20soon%20as%20i%20have%20time.%20Maybe%20tomorrow%20else%20monday.%22%2C%20%22created_at%22%3A%20%222015-01-10T17%3A39%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7575436%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DDaems%22%7D%7D%2C%20%7B%22body%22%3A%20%22Finnaly%20centered%2C%20when%20i%20realised%20i%20could%20use%20classes%20on%20body%20and%20html%20tags%20too.%5Cr%5CnIt%20was%20easy%20to%20move%20the%20css%20to%20the%20_stylesheet.%20%5Cr%5CnI%20tried%20various%20ways%2C%20of%20using%20wrappers.%20But%20there%20was%20allways%20a%20problem%20to%20get%20it%20centered%20vertically.%5Cr%5CnThis%20was%20the%20best%20solution%20i%20could%20come%20up%20with.%20To%20keep%20it%20responsive%20over%20all%20screensizes.%22%2C%20%22created_at%22%3A%20%222015-01-11T03%3A32%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7575436%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DDaems%22%7D%7D%2C%20%7B%22body%22%3A%20%22pfff%2C%20i%20don%27t%20get%20it%20why%20it%20keeps%20complaining%20about%20unexpected%20tabs.%5Cr%5CnWhile%20all%20others%20are%20exactly%20the%20same%20and%20he%20isn%27t%20complaining%20about%20it.%5Cr%5Cn%5Cr%5CnI%27ll%20give%20that%20grunt%20installation%20a%20shot%2C%20so%20i%20could%20validate%20and%20learn%20a%20bit%20more%20about%20it.%22%2C%20%22created_at%22%3A%20%222015-01-12T09%3A22%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7575436%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DDaems%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20problem%20is%20that%20you%20are%20using%20tabs%20and%20not%20spaces%20%3B%29%22%2C%20%22created_at%22%3A%20%222015-01-12T09%3A24%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415280%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Phhere%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40DDaems%20if%20you%20find%20your%20Editor%20here%20you%20can%20use%20our%20.editorconfig%20which%20will%20take%20care%20of%20this%20issue%20%3B%29%22%2C%20%22created_at%22%3A%20%222015-01-12T09%3A26%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/498197%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Pascalmh%22%7D%7D%2C%20%7B%22body%22%3A%20%22%60%60%60%5Cr%5CnFILE%3A%20/var/snap-ci/repo/checklogin.php%5Cr%5Cn--------------------------------------------------------------------------------%5Cr%5CnFOUND%203%20ERRORS%20AFFECTING%202%20LINES%5Cr%5Cn--------------------------------------------------------------------------------%5Cr%5Cn%20197%20%7C%20ERROR%20%7C%20%5Bx%5D%20Line%20indented%20incorrectly%3B%20expected%20at%20least%2012%20spaces%2C%5Cr%5Cn%20%20%20%20%20%7C%20%20%20%20%20%20%20%7C%20%20%20%20%20found%208%20%28Generic.WhiteSpace.ScopeIndent.Incorrect%29%5Cr%5Cn%20198%20%7C%20ERROR%20%7C%20%5Bx%5D%20Line%20indented%20incorrectly%3B%20expected%200%20spaces%2C%20found%204%5Cr%5Cn%20%20%20%20%20%7C%20%20%20%20%20%20%20%7C%20%20%20%20%20%28Generic.WhiteSpace.ScopeIndent.IncorrectExact%29%5Cr%5Cn%20198%20%7C%20ERROR%20%7C%20%5Bx%5D%20Closing%20brace%20indented%20incorrectly%3B%20expected%200%20spaces%2C%20found%5Cr%5Cn%20%20%20%20%20%7C%20%20%20%20%20%20%20%7C%20%20%20%20%204%20%28Squiz.WhiteSpace.ScopeClosingBrace.Indent%29%5Cr%5Cn--------------------------------------------------------------------------------%5Cr%5CnPHPCBF%20CAN%20FIX%20THE%203%20MARKED%20SNIFF%20VIOLATIONS%20AUTOMATICALLY%5Cr%5Cn--------------------------------------------------------------------------------%5Cr%5Cn%5Cr%5Cn%5Cr%5CnFILE%3A%20/var/snap-ci/repo/_stylesheet.css%5Cr%5Cn--------------------------------------------------------------------------------%5Cr%5CnFOUND%201%20ERROR%20AFFECTING%201%20LINE%5Cr%5Cn--------------------------------------------------------------------------------%5Cr%5Cn%20125%20%7C%20ERROR%20%7C%20%5Bx%5D%20Spaces%20must%20be%20used%20for%20alignment%3B%20tabs%20are%20not%20allowed%5Cr%5Cn%20%20%20%20%20%7C%20%20%20%20%20%20%20%7C%20%20%20%20%20%28Generic.WhiteSpace.DisallowTabIndent.NonIndentTabsUsed%29%5Cr%5Cn--------------------------------------------------------------------------------%5Cr%5CnPHPCBF%20CAN%20FIX%20THE%201%20MARKED%20SNIFF%20VIOLATIONS%20AUTOMATICALLY%5Cr%5Cn--------------------------------------------------------------------------------%5Cr%5Cn%5Cr%5CnTime%3A%209%20secs%3B%20Memory%3A%2033.25Mb%5Cr%5Cn%5Cr%5CnFatal%20error%3A%20Command%20failed%3A%20%5Cu0007%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnUhm%20this%20is%20unexpected%2C%20%5Cr%5Cnand%20i%20didn%27t%20even%20though%20line%20125%20-_-%5Cr%5CnSeems%20like%20it%20should%20be%20able%20to%20fix%20those%20errors%20itself%2C%20but%20its%20troing%20a%20fatal%20error%20%3A%28%5Cr%5Cn%5Cr%5CnI%20tried%20installing%20grunt%2C%20but%20it%20seems%20to%20take%20forever%20with%20my%20inet%20connection%20to%20install%20all%20packages.%5Cr%5CnOr%20its%20doing%20nothing%20%3A%28%22%2C%20%22created_at%22%3A%20%222015-01-14T23%3A51%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7575436%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/DDaems%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20Pull%20Request%20might%20not%20be%20needed%20anymore%20if%20we%20manage%20to%20merge%20checklogin.php%20with%20login.php%20https%3A//github.com/webSPELL/webSPELL-4.2.3/issues/168%22%2C%20%22created_at%22%3A%20%222015-01-17T15%3A01%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/498197%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Pascalmh%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/webSPELL/webSPELL-4.2.3/pull/130#issuecomment-69452906'>General Comment</a></b>
- <a href='https://github.com/derchrisuk'><img border=0 src='https://avatars.githubusercontent.com/u/706758?v=3' height=16 width=16'></a> Why add inline CSS for this?
It only needs the Bootstrap includes.
- <a href='https://github.com/DDaems'><img border=0 src='https://avatars.githubusercontent.com/u/7575436?v=3' height=16 width=16'></a> The inline css is used, to display it vertically in the middle of your browser.
Else it would be at the top of the page, and it didn't really look nice imo.
I have no idea, how to archieve this in any other way. Without altering some properties trough inline css.
- <a href='https://github.com/Pascalmh'><img border=0 src='https://avatars.githubusercontent.com/u/498197?v=3' height=16 width=16'></a> We are not using the fluid grid anywhere else - this should be switched to the static grid.
Instead of using inline style put this stuff into the _stylesheet, however I don't think we need to alter any Bootstrap CSS at this point.
I think we can use [Flexbox](http://caniuse.com/#search=flexbox) here - see: http://stackoverflow.com/questions/20547819/vertical-align-with-bootstrap-3/25517025#25517025
- <a href='https://github.com/DDaems'><img border=0 src='https://avatars.githubusercontent.com/u/7575436?v=3' height=16 width=16'></a> I tried flexbox, but had some troubles getting the alertbox horizontal centered.
Thats the reason why i went with a alternavite approach.
But i'll try it again with the link u provided..
I used fluid, to have the alert message box reach the side of the browser.
Though it has a nicer appeal to it.
I'll update it as soon as i have time. Maybe tomorrow else monday.
- <a href='https://github.com/DDaems'><img border=0 src='https://avatars.githubusercontent.com/u/7575436?v=3' height=16 width=16'></a> Finnaly centered, when i realised i could use classes on body and html tags too.
It was easy to move the css to the _stylesheet.
I tried various ways, of using wrappers. But there was allways a problem to get it centered vertically.
This was the best solution i could come up with. To keep it responsive over all screensizes.
- <a href='https://github.com/DDaems'><img border=0 src='https://avatars.githubusercontent.com/u/7575436?v=3' height=16 width=16'></a> pfff, i don't get it why it keeps complaining about unexpected tabs.
While all others are exactly the same and he isn't complaining about it.
I'll give that grunt installation a shot, so i could validate and learn a bit more about it.
- <a href='https://github.com/Phhere'><img border=0 src='https://avatars.githubusercontent.com/u/1415280?v=3' height=16 width=16'></a> The problem is that you are using tabs and not spaces ;)
- <a href='https://github.com/Pascalmh'><img border=0 src='https://avatars.githubusercontent.com/u/498197?v=3' height=16 width=16'></a> @DDaems if you find your Editor here you can use our .editorconfig which will take care of this issue ;)
- <a href='https://github.com/DDaems'><img border=0 src='https://avatars.githubusercontent.com/u/7575436?v=3' height=16 width=16'></a> 
```
FILE: /var/snap-ci/repo/checklogin.php
--------------------------------------------------------------------------------
FOUND 3 ERRORS AFFECTING 2 LINES
--------------------------------------------------------------------------------
197 | ERROR | [x] Line indented incorrectly; expected at least 12 spaces,
|       |     found 8 (Generic.WhiteSpace.ScopeIndent.Incorrect)
198 | ERROR | [x] Line indented incorrectly; expected 0 spaces, found 4
|       |     (Generic.WhiteSpace.ScopeIndent.IncorrectExact)
198 | ERROR | [x] Closing brace indented incorrectly; expected 0 spaces, found
|       |     4 (Squiz.WhiteSpace.ScopeClosingBrace.Indent)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 3 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------
FILE: /var/snap-ci/repo/_stylesheet.css
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
125 | ERROR | [x] Spaces must be used for alignment; tabs are not allowed
|       |     (Generic.WhiteSpace.DisallowTabIndent.NonIndentTabsUsed)
--------------------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
--------------------------------------------------------------------------------
Time: 9 secs; Memory: 33.25Mb
Fatal error: Command failed: 
```
Uhm this is unexpected,
and i didn't even though line 125 -_-
Seems like it should be able to fix those errors itself, but its troing a fatal error :(
I tried installing grunt, but it seems to take forever with my inet connection to install all packages.
Or its doing nothing :(
- <a href='https://github.com/Pascalmh'><img border=0 src='https://avatars.githubusercontent.com/u/498197?v=3' height=16 width=16'></a> This Pull Request might not be needed anymore if we manage to merge checklogin.php with login.php https://github.com/webSPELL/webSPELL-4.2.3/issues/168


<a href='https://www.codereviewhub.com/webSPELL/webSPELL-4.2.3/pull/130?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/webSPELL/webSPELL-4.2.3/pull/130?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/webSPELL/webSPELL-4.2.3/pull/130'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>